### PR TITLE
fix: per-model sensor property resolution for Eletta Explore (v0.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1] - 2026-06-03
+
+### Fixed
+- Sensors stuck on `unknown` for Eletta Explore (`oem_model=DL-striker-cb`): counter property names now resolve from a per-model candidate list (e.g. `d700_tot_bev_b` on Soul vs `d701_tot_bev_b` on Eletta), same approach as the v0.3.0 command-property detection.
+- `Last Connected` now resolves `device_connected` / `app_device_connected` via the candidate list (the previous one-off fallback is removed).
+
+### Changed
+- Counter/info sensors whose property is absent on the device are no longer created, instead of appearing permanently `unknown` (e.g. Total Milk Drinks / Total Water / Descale Status on Eletta).
+- Counter parsing is more robust (handles int and numeric strings); when a counter value is present but not a plain integer, the raw value and Ayla `base_type` are logged once so unknown encodings can be reported and supported.
+
+## [0.3.0] - 2026-05-21
+
+### Added
+- Auto-detection of the binary command property at first refresh (`data_request` on PrimaDonna Soul / `app_data_request` on Eletta Explore), fixing `HTTP 404` on `set_property` for non-Soul models.
+
 ## [0.2.0] - 2026-04-22
 
 ### Added

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -74,28 +74,35 @@ BEVERAGES = [
     (0x1b, "brew_over_ice",   "Brew Over Ice",    "mdi:coffee"),
 ]
 
-# Counter properties to expose as sensors: (property_name, entity_key, display_name, icon)
+# Counter properties to expose as sensors:
+#   (candidate_property_names, entity_key, display_name, icon)
+# Property names differ between models; the first candidate present on the device
+# wins (same approach as COMMAND_PROPERTY_CANDIDATES). A sensor whose property is
+# absent on the device is not created (avoids permanently-"unknown" entities).
+#   - PrimaDonna Soul (DL-millcore): d700_tot_bev_b, d701_tot_bev_bw, d703_tot_bev_w, d825_descale_status
+#   - Eletta Explore (DL-striker-cb): d701_tot_bev_b (no milk/water/descale equivalents exposed)
 COUNTER_SENSORS = [
-    ("d700_tot_bev_b",         "total_beverages",     "Total Beverages",     "mdi:counter"),
-    ("d704_tot_bev_espressi",  "total_espresso",      "Total Espresso",      "mdi:coffee"),
-    ("d701_tot_bev_bw",        "total_milk_drinks",   "Total Milk Drinks",   "mdi:cup"),
-    ("d703_tot_bev_w",         "total_water",         "Total Water",         "mdi:water"),
-    ("d710_tot_id7_capp",      "total_cappuccino",    "Total Cappuccino",    "mdi:coffee"),
-    ("d711_id8_lattmacc",      "total_latte_macchiato", "Total Latte Macchiato", "mdi:coffee"),
-    ("d712_id9_cafflatt",      "total_caffelatte",    "Total Caffe Latte",   "mdi:coffee"),
-    ("d715_id12_hotmilk",      "total_hot_milk",      "Total Hot Milk",      "mdi:cup"),
-    ("d718_id16_hotwater",     "total_hot_water",     "Total Hot Water",     "mdi:water"),
-    ("d719_id22_tea",          "total_tea",           "Total Tea",           "mdi:tea"),
-    ("d720_tot_id23_coffee_pot", "total_coffee_pot",  "Total Coffee Pot",    "mdi:coffee-maker"),
-    ("d551_cnt_coffee_fondi",  "grounds_counter",     "Grounds Counter",     "mdi:dots-grid"),
-    ("d825_descale_status",    "descale_status",      "Descale Status",      "mdi:water-pump"),
-    ("d556_water_hardness",    "water_hardness",      "Water Hardness",      "mdi:water-percent"),
+    (["d700_tot_bev_b", "d701_tot_bev_b"], "total_beverages",       "Total Beverages",       "mdi:counter"),
+    (["d704_tot_bev_espressi"],            "total_espresso",        "Total Espresso",        "mdi:coffee"),
+    (["d701_tot_bev_bw"],                  "total_milk_drinks",     "Total Milk Drinks",     "mdi:cup"),
+    (["d703_tot_bev_w"],                   "total_water",           "Total Water",           "mdi:water"),
+    (["d710_tot_id7_capp"],                "total_cappuccino",      "Total Cappuccino",      "mdi:coffee"),
+    (["d711_id8_lattmacc"],                "total_latte_macchiato", "Total Latte Macchiato", "mdi:coffee"),
+    (["d712_id9_cafflatt"],                "total_caffelatte",      "Total Caffe Latte",     "mdi:coffee"),
+    (["d715_id12_hotmilk"],                "total_hot_milk",        "Total Hot Milk",        "mdi:cup"),
+    (["d718_id16_hotwater"],               "total_hot_water",       "Total Hot Water",       "mdi:water"),
+    (["d719_id22_tea"],                    "total_tea",             "Total Tea",             "mdi:tea"),
+    (["d720_tot_id23_coffee_pot"],         "total_coffee_pot",      "Total Coffee Pot",      "mdi:coffee-maker"),
+    (["d551_cnt_coffee_fondi"],            "grounds_counter",       "Grounds Counter",       "mdi:dots-grid"),
+    (["d825_descale_status"],              "descale_status",        "Descale Status",        "mdi:water-pump"),
+    (["d556_water_hardness"],              "water_hardness",        "Water Hardness",        "mdi:water-percent"),
 ]
 
-# Info sensors (not counters, general state)
+# Info sensors (not counters, general state):
+#   (candidate_property_names, entity_key, display_name, icon)
 INFO_SENSORS = [
-    ("software_version",       "software_version",    "Software Version",    "mdi:chip"),
-    ("device_connected",       "last_connected",      "Last Connected",      "mdi:clock-outline"),
+    (["software_version"],                         "software_version", "Software Version", "mdi:chip"),
+    (["device_connected", "app_device_connected"], "last_connected",   "Last Connected",   "mdi:clock-outline"),
 ]
 
 PLATFORMS = ["sensor", "button"]

--- a/custom_components/delonghi_coffeelink/manifest.json
+++ b/custom_components/delonghi_coffeelink/manifest.json
@@ -10,5 +10,5 @@
   "issue_tracker": "https://github.com/actabi/delonghi_coffeelink/issues",
   "loggers": ["custom_components.delonghi_coffeelink"],
   "requirements": [],
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/custom_components/delonghi_coffeelink/sensor.py
+++ b/custom_components/delonghi_coffeelink/sensor.py
@@ -17,6 +17,19 @@ from .coordinator import DelonghiCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+def _resolve_property(data: dict[str, Any] | None, candidates: list[str]) -> str | None:
+    """Return the first candidate property name present on the device, else None.
+
+    Property names differ across DeLonghi models (e.g. d700_tot_bev_b on Soul vs
+    d701_tot_bev_b on Eletta Explore), so each sensor declares a candidate list.
+    """
+    data = data or {}
+    for candidate in candidates:
+        if candidate in data:
+            return candidate
+    return None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -25,11 +38,25 @@ async def async_setup_entry(
     coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
     entities: list[SensorEntity] = []
     for coord in coordinators:
-        for prop_name, key, friendly, icon in COUNTER_SENSORS:
+        for candidates, key, friendly, icon in COUNTER_SENSORS:
+            prop_name = _resolve_property(coord.data, candidates)
+            if prop_name is None:
+                _LOGGER.debug(
+                    "Skipping counter '%s' for dsn=%s: none of %s present",
+                    key, coord.device.dsn, candidates,
+                )
+                continue
             entities.append(
                 DelonghiCounterSensor(coord, prop_name, key, friendly, icon)
             )
-        for prop_name, key, friendly, icon in INFO_SENSORS:
+        for candidates, key, friendly, icon in INFO_SENSORS:
+            prop_name = _resolve_property(coord.data, candidates)
+            if prop_name is None:
+                _LOGGER.debug(
+                    "Skipping info sensor '%s' for dsn=%s: none of %s present",
+                    key, coord.device.dsn, candidates,
+                )
+                continue
             entities.append(DelonghiInfoSensor(coord, prop_name, key, friendly, icon))
         entities.append(DelonghiConnectionSensor(coord))
     async_add_entities(entities)
@@ -72,6 +99,7 @@ class DelonghiCounterSensor(_Base):
     ) -> None:
         super().__init__(coord, key, friendly, icon)
         self._prop_name = prop_name
+        self._logged_unparseable = False
 
     @property
     def native_value(self) -> int | None:
@@ -79,20 +107,38 @@ class DelonghiCounterSensor(_Base):
         if not prop:
             return None
         val = prop.get("value")
+        if val is None:
+            return None
+        # Soul exposes counters as plain integers. Some models may wrap the value
+        # differently (e.g. a base64 binary blob); don't guess the layout - parse
+        # what we can and log the raw value once so the format can be confirmed.
+        if isinstance(val, bool):
+            return None
+        if isinstance(val, int):
+            return val
         try:
-            return int(val) if val is not None else None
+            return int(str(val).strip())
         except (TypeError, ValueError):
+            if not self._logged_unparseable:
+                self._logged_unparseable = True
+                _LOGGER.warning(
+                    "Counter '%s' (%s): value is not a plain integer "
+                    "(base_type=%s, raw=%r). Sensor left unknown - please report "
+                    "this raw value so the parser can be extended.",
+                    self._prop_name,
+                    self._attr_name,
+                    prop.get("base_type"),
+                    val,
+                )
             return None
 
 
 class DelonghiInfoSensor(_Base):
-    """Generic info sensor (version string, timestamp, etc.)."""
+    """Generic info sensor (version string, timestamp, etc.).
 
-    # Some property names differ across DeLonghi models (e.g. device_connected
-    # vs app_device_connected). When the primary name is missing, try a fallback.
-    _FALLBACKS = {
-        "device_connected": "app_device_connected",
-    }
+    The concrete property name is resolved per-model at setup time (see
+    INFO_SENSORS candidate lists), so no name fallback is needed here.
+    """
 
     def __init__(
         self,
@@ -107,10 +153,7 @@ class DelonghiInfoSensor(_Base):
 
     @property
     def native_value(self) -> Any:
-        data = self.coordinator.data or {}
-        prop = data.get(self._prop_name)
-        if not prop and self._prop_name in self._FALLBACKS:
-            prop = data.get(self._FALLBACKS[self._prop_name])
+        prop = (self.coordinator.data or {}).get(self._prop_name)
         if not prop:
             return None
         return prop.get("value")


### PR DESCRIPTION
## Problem

On Eletta Explore (`oem_model=DL-striker-cb`) every counter/info sensor stays `unknown` except Connection Status, Last Connected and Software Version (see #2). Root cause: the counter property names were taken from the PrimaDonna Soul (`DL-millcore`) the integration was built against, and several differ on the Eletta - e.g. `d700_tot_bev_b` (Soul) vs `d701_tot_bev_b` (Eletta), and `device_connected` vs `app_device_connected`.

## Fix

Same pattern as the v0.3.0 command-property auto-detection, applied to sensors:

- `COUNTER_SENSORS` / `INFO_SENSORS` now declare a **candidate property list**, resolved against the device at setup. First present name wins.
- Sensors whose property is absent are **not created** (no more permanently-`unknown` Total Milk Drinks / Total Water / Descale Status on Eletta).
- Counter parsing handles `int` and numeric strings; a value that is present but **not** a plain integer is logged **once** with its Ayla `base_type` + raw value, so any unknown encoding (e.g. base64 blob) can be reported and supported rather than silently guessed.
- `Last Connected` resolves `device_connected` / `app_device_connected` via the list (removes the previous one-off fallback).

## No regression on PrimaDonna Soul

Resolution simulated against both property sets:

- **Soul (DL-millcore):** all 16 sensors still resolve (`total_beverages -> d700_tot_bev_b`, `last_connected -> device_connected`). 0 skipped.
- **Eletta (DL-striker-cb):** 13 sensors created (`total_beverages -> d701_tot_bev_b`, `last_connected -> app_device_connected`), 3 model-absent sensors skipped.

## Notes

- Bumps version to `0.3.1`, adds CHANGELOG entries for `0.3.1` and the previously-undocumented `0.3.0`.
- If the Eletta counters turn out to be base64 blobs, this PR will not yet *display* them but will surface the raw value in the logs to drive a follow-up decoder. Closes the sensor-naming half of #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)