### PR TITLE
feat: enhance cloud session management and diagnostics

### DIFF
--- a/custom_components/delonghi_coffeelink/__init__.py
+++ b/custom_components/delonghi_coffeelink/__init__.py
@@ -93,6 +93,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        for coord in hass.data.get(DOMAIN, {}).get(entry.entry_id, []):
+            if coord.profile.uses_cloud_session:
+                await coord.async_shutdown()
         hass.data[DOMAIN].pop(entry.entry_id, None)
     return unload_ok
 

--- a/custom_components/delonghi_coffeelink/ayla_client.py
+++ b/custom_components/delonghi_coffeelink/ayla_client.py
@@ -5,6 +5,7 @@ Auth chain: Gigya email/password login -> Gigya JWT (HMAC-SHA1 signed request)
 """
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -20,8 +21,12 @@ import aiohttp
 from .const import (
     APP_ID,
     APP_SECRET,
+    APP_ID_PROPERTY,
     AYLA_EU_ADS_URL,
     AYLA_EU_USER_URL,
+    CLOUD_HTTP_RETRY_BACKOFF,
+    CLOUD_HTTP_RETRY_COUNT,
+    CLOUD_TRANSIENT_HTTP_CODES,
     GIGYA_API_KEY,
     GIGYA_BASE_URL,
 )
@@ -35,6 +40,10 @@ class AuthError(Exception):
 
 class CloudError(Exception):
     """Raised for Ayla API errors."""
+
+    def __init__(self, message: str, *, http_status: int | None = None) -> None:
+        super().__init__(message)
+        self.http_status = http_status
 
 
 @dataclass
@@ -76,11 +85,120 @@ class DelonghiAylaClient:
         if not self._access_token or time.time() > self._expires_at - 30:
             await self.async_authenticate()
 
+    def _auth_headers(self) -> dict[str, str]:
+        return {"Authorization": f"auth_token {self._access_token}"}
+
+    @staticmethod
+    def _value_hint(value: Any) -> str:
+        if isinstance(value, str):
+            return f"len={len(value)}"
+        return type(value).__name__
+
+    def _log_http(
+        self,
+        method: str,
+        url: str,
+        status: int,
+        elapsed_ms: float,
+        *,
+        detail: str = "",
+    ) -> None:
+        msg = "%s %s -> HTTP %d (%.0fms)%s"
+        args: tuple[Any, ...] = (method, url, status, elapsed_ms, detail)
+        if status >= 400:
+            _LOGGER.warning(msg, *args)
+        else:
+            _LOGGER.debug(msg, *args)
+
+    async def _request_json(
+        self,
+        method: str,
+        url: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        data: dict[str, str] | None = None,
+        ok_status: frozenset[int] | set[int] | None = None,
+        op: str = "",
+    ) -> Any:
+        """HTTP request with transient retry (Eletta session paths only)."""
+        await self.async_ensure_auth()
+        if ok_status is None:
+            ok_status = frozenset({200, 201})
+        last_error: CloudError | None = None
+        for attempt in range(CLOUD_HTTP_RETRY_COUNT + 1):
+            started = time.monotonic()
+            try:
+                async with self._session.request(
+                    method,
+                    url,
+                    headers=self._auth_headers(),
+                    json=json_body,
+                    data=data,
+                ) as resp:
+                    elapsed_ms = (time.monotonic() - started) * 1000
+                    text = await resp.text()
+                    detail = f" [{op}]" if op else ""
+                    if json_body and "datapoint" in json_body:
+                        prop_val = json_body["datapoint"].get("value")
+                        detail += f" value={self._value_hint(prop_val)}"
+                    self._log_http(method, url, resp.status, elapsed_ms, detail=detail)
+
+                    if resp.status in CLOUD_TRANSIENT_HTTP_CODES and attempt < CLOUD_HTTP_RETRY_COUNT:
+                        _LOGGER.warning(
+                            "Ayla transient HTTP %d on %s %s; retry %d/%d in %.1fs",
+                            resp.status,
+                            method,
+                            op or url.rsplit("/", 1)[-1],
+                            attempt + 1,
+                            CLOUD_HTTP_RETRY_COUNT,
+                            CLOUD_HTTP_RETRY_BACKOFF * (attempt + 1),
+                        )
+                        await asyncio.sleep(CLOUD_HTTP_RETRY_BACKOFF * (attempt + 1))
+                        continue
+
+                    if resp.status not in ok_status:
+                        raise CloudError(
+                            f"{op or method} failed (HTTP {resp.status}): {text[:300]}",
+                            http_status=resp.status,
+                        )
+
+                    if not text.strip():
+                        return None
+                    try:
+                        return json.loads(text)
+                    except json.JSONDecodeError as err:
+                        raise CloudError(
+                            f"{op or method}: expected JSON, got {resp.content_type!r}: "
+                            f"{text[:200]}",
+                            http_status=resp.status,
+                        ) from err
+            except aiohttp.ClientError as err:
+                elapsed_ms = (time.monotonic() - started) * 1000
+                last_error = CloudError(
+                    f"{op or method} network error after {elapsed_ms:.0f}ms: {err}"
+                )
+                if attempt < CLOUD_HTTP_RETRY_COUNT:
+                    _LOGGER.warning(
+                        "Ayla network error on %s %s; retry %d/%d: %s",
+                        method,
+                        op or url.rsplit("/", 1)[-1],
+                        attempt + 1,
+                        CLOUD_HTTP_RETRY_COUNT,
+                        err,
+                    )
+                    await asyncio.sleep(CLOUD_HTTP_RETRY_BACKOFF * (attempt + 1))
+                    continue
+                raise last_error from err
+
+        if last_error:
+            raise last_error
+        raise CloudError(f"{op or method} failed after retries")
+
     async def _gigya_login_and_jwt(self) -> str:
         """Login to Gigya + get JWT via signed request (HMAC-SHA1 with sessionSecret)."""
-        # 1. accounts.login
+        login_url = f"{GIGYA_BASE_URL}/accounts.login"
         async with self._session.post(
-            f"{GIGYA_BASE_URL}/accounts.login",
+            login_url,
             data={
                 "apiKey": GIGYA_API_KEY,
                 "loginID": self._email,
@@ -96,7 +214,6 @@ class DelonghiAylaClient:
         session_token = body["sessionInfo"]["sessionToken"]
         session_secret = body["sessionInfo"]["sessionSecret"]
 
-        # 2. accounts.getJWT with HMAC-SHA1 signature
         timestamp = str(int(time.time()))
         nonce = f"{timestamp}_1"
         url = f"{GIGYA_BASE_URL}/accounts.getJWT"
@@ -135,9 +252,6 @@ class DelonghiAylaClient:
         self._access_token = body["access_token"]
         self._refresh_token = body.get("refresh_token")
         self._expires_at = time.time() + body.get("expires_in", 3600)
-
-    def _auth_headers(self) -> dict[str, str]:
-        return {"Authorization": f"auth_token {self._access_token}"}
 
     async def async_get_devices(self) -> list[AylaDevice]:
         """List all Ayla devices tied to this account."""
@@ -207,6 +321,29 @@ class DelonghiAylaClient:
             raise CloudError(f"get_property {property_name}: unexpected response {data!r}")
         return prop
 
+    async def async_get_property_resilient(
+        self, dsn: str, property_name: str
+    ) -> dict[str, Any]:
+        """Eletta-only: GET with retry (confirm loop live app_id polling)."""
+        url = f"{AYLA_EU_ADS_URL}/apiv1/dsns/{dsn}/properties/{property_name}.json"
+        data = await self._request_json(
+            "GET",
+            url,
+            ok_status=frozenset({200}),
+            op=f"get {property_name} dsn={dsn}",
+        )
+        prop = data.get("property")
+        if not isinstance(prop, dict):
+            raise CloudError(f"get_property {property_name}: unexpected response {data!r}")
+        raw = prop.get("value")
+        _LOGGER.debug(
+            "Property %s dsn=%s value=%s",
+            property_name,
+            dsn,
+            raw if property_name == APP_ID_PROPERTY else self._value_hint(raw),
+        )
+        return prop
+
     async def async_post_cloud_session(
         self, dsn: str, connected_property: str, integration_app_id: int
     ) -> dict[str, Any]:
@@ -219,7 +356,26 @@ class DelonghiAylaClient:
             now_s.to_bytes(4, "big", signed=False)
             + integration_app_id_to_bytes(integration_app_id)
         ).decode("utf-8")
-        return await self.async_set_property_value(dsn, connected_property, payload)
+        _LOGGER.info(
+            "POST cloud session connect dsn=%s property=%s app_id=%d (0x%08x) payload_len=%d",
+            dsn,
+            connected_property,
+            integration_app_id,
+            integration_app_id & 0xFFFFFFFF,
+            len(payload),
+        )
+        url = (
+            f"{AYLA_EU_ADS_URL}/apiv1/dsns/{dsn}/properties/"
+            f"{connected_property}/datapoints.json"
+        )
+        result = await self._request_json(
+            "POST",
+            url,
+            json_body={"datapoint": {"value": payload}},
+            ok_status=frozenset({200, 201}),
+            op=f"set {connected_property} dsn={dsn}",
+        )
+        return result or {}
 
 
 def normalize_signed_app_id(app_id: int) -> int:

--- a/custom_components/delonghi_coffeelink/command_builder.py
+++ b/custom_components/delonghi_coffeelink/command_builder.py
@@ -16,12 +16,19 @@ from .const import (
     CRC_POLY,
     DEFAULT_RECIPE_PARAMS,
     ELETTA_RECIPE_TRAILER,
+    POWER_SESSION_REFRESH_PARAMS,
     POWER_STANDBY_PARAMS,
     POWER_WAKE_PARAMS,
 )
 
 _BEV_NAMES = {bev_id: display for bev_id, _key, display, _icon in BEVERAGES}
 _ACTION_NAMES = {0x01: "start", 0x02: "stop"}
+
+
+def _session_id_to_tail_bytes(app_id: int) -> bytes:
+    """Encode cloud session app id as signed int32 BE (DlghIoT / ayla_client convention)."""
+    signed = ((app_id & 0xFFFFFFFF) ^ 0x80000000) - 0x80000000
+    return signed.to_bytes(4, "big", signed=True)
 
 
 def crc16_aug_ccitt(data: bytes) -> int:
@@ -224,6 +231,54 @@ def build_wake_command(timestamp: int | None = None) -> bytes:
 def build_wake_encoded() -> str:
     """Shortcut: build wake command + base64 encode."""
     return encode_command(build_wake_command())
+
+
+def build_wake_with_session_tail(app_id: int, timestamp: int | None = None) -> bytes:
+    """Wake/power-on with the cloud session id in the 4-byte tail (DlghIoT resume)."""
+    return build_power_command(
+        POWER_WAKE_PARAMS, timestamp, _session_id_to_tail_bytes(app_id)
+    )
+
+
+def build_wake_with_session_tail_encoded(app_id: int) -> str:
+    return encode_command(build_wake_with_session_tail(app_id))
+
+
+def build_standby_with_session_tail(app_id: int, timestamp: int | None = None) -> bytes:
+    """Standby with the cloud session id in the 4-byte tail (DlghIoT standby)."""
+    return build_power_command(
+        POWER_STANDBY_PARAMS, timestamp, _session_id_to_tail_bytes(app_id)
+    )
+
+
+def build_standby_with_session_tail_encoded(app_id: int) -> str:
+    return encode_command(build_standby_with_session_tail(app_id))
+
+
+def build_session_refresh_command(app_id: int, timestamp: int | None = None) -> bytes:
+    """Deep-standby session nudge (DlghIoT refresh(), params 03 02)."""
+    return build_power_command(
+        POWER_SESSION_REFRESH_PARAMS, timestamp, _session_id_to_tail_bytes(app_id)
+    )
+
+
+def build_session_refresh_encoded(app_id: int) -> str:
+    return encode_command(build_session_refresh_command(app_id))
+
+
+def validate_power_frame_b64(value_b64: str, expected_params: bytes) -> bool:
+    """True if a base64 frame is a valid power command with the expected params."""
+    decoded = decode_command(value_b64)
+    return (
+        decoded.get("type") == "power"
+        and decoded.get("params") == expected_params.hex(" ")
+        and decoded.get("crc_valid") is True
+    )
+
+
+def validate_replayed_wake_frame(value_b64: str) -> bool:
+    """Validate a learned/replayed wake frame before send (params 02 01, CRC ok)."""
+    return validate_power_frame_b64(value_b64, POWER_WAKE_PARAMS)
 
 
 def build_standby_command(

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -35,6 +35,13 @@ INTEGRATION_CLOUD_APP_ID = 0xC0FFEE11
 APP_ID_PROPERTY = "app_id"  # machine property: current session holder
 CONNECT_REFRESH_INTERVAL = 240  # refresh before 4*60s (device timeout ~300s)
 CONNECT_SETTLE_DELAY = 4  # sleep after POST connect (background tasks only)
+CONNECT_CONFIRM_TIMEOUT = 300  # poll app_id after POST (Eletta; can exceed 180s on bad cloud days)
+CONNECT_CONFIRM_POLL_INTERVAL = 1  # seconds between app_id polls during confirm
+
+# Ayla HTTP resilience (502/503/504 gateway timeouts seen on ads-eu.aylanetworks.com).
+CLOUD_HTTP_RETRY_COUNT = 2
+CLOUD_HTTP_RETRY_BACKOFF = 1.5  # seconds; multiplied by attempt index
+CLOUD_TRANSIENT_HTTP_CODES = frozenset({429, 502, 503, 504})
 
 # Config
 CONF_EMAIL = "email"
@@ -67,6 +74,8 @@ POWER_WAKE_PARAMS = bytes([0x02, 0x01])  # observed wake command payload
 # Standby (power off) payload - reported on Eletta (issue #1) and validated
 # live on the reference PrimaDonna Soul (machine powered off, 2026-06-07).
 POWER_STANDBY_PARAMS = bytes([0x01, 0x01])
+# Session refresh / deep-standby nudge (DlghIoT refresh(), params 03 02, CRC 5640).
+POWER_SESSION_REFRESH_PARAMS = bytes([0x03, 0x02])
 
 # Machine monitor (d302_monitor_machine) - operational state published by the
 # machine. Status codes from the DlghIoT client (framagit.org/mattgk/dlghiot),

--- a/custom_components/delonghi_coffeelink/coordinator.py
+++ b/custom_components/delonghi_coffeelink/coordinator.py
@@ -16,17 +16,26 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .ayla_client import AylaDevice, CloudError, DelonghiAylaClient, normalize_signed_app_id
 from .command_builder import (
     builder_structural_b64,
+    build_session_refresh_encoded,
+    build_standby_encoded,
+    build_standby_with_session_tail_encoded,
+    build_wake_encoded,
+    build_wake_with_session_tail_encoded,
     decode_command,
     deserialize_learned_frames,
     is_wake_power_frame,
     recipe_dump_lines,
+    replay_with_timestamp,
     serialize_learned_frames,
     summarize_decoded,
+    validate_replayed_wake_frame,
 )
 from .const import (
     ACTION_STOP,
     APP_ID_PROPERTY,
     COMMAND_PROPERTY_CANDIDATES,
+    CONNECT_CONFIRM_POLL_INTERVAL,
+    CONNECT_CONFIRM_TIMEOUT,
     CONNECT_REFRESH_INTERVAL,
     CONNECT_SETTLE_DELAY,
     CONNECTED_PROPERTY_CANDIDATES,
@@ -76,8 +85,11 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_connect_at: float = 0
         self._session_confirmed = False
         self._session_connect_lock = asyncio.Lock()
-        self._session_refresh_task: asyncio.Task[None] | None = None
         self._session_cold_task: asyncio.Task[None] | None = None
+        if self.profile.uses_cloud_session:
+            self._last_seen_app_id: int | None = None
+        else:
+            self._session_refresh_task: asyncio.Task[None] | None = None
         # --- Command sniffer state ---------------------------------------
         # Values WE wrote, so a command echoed back by the cloud is not
         # mis-attributed to the official app. Bounded; only recent writes matter.
@@ -109,6 +121,16 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             hass, RECIPE_STORE_VERSION, f"{DOMAIN}_recipes_{device.dsn}"
         )
 
+    async def async_shutdown(self) -> None:
+        """Cancel in-flight session work and reset session state on unload."""
+        if self._session_cold_task and not self._session_cold_task.done():
+            self._session_cold_task.cancel()
+        self._session_cold_task = None
+        self._last_connect_at = 0
+        if self._integration_app_id != self._default_app_id:
+            self._integration_app_id = self._default_app_id
+        await super().async_shutdown()
+
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch all properties + refresh device meta."""
         try:
@@ -133,7 +155,6 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._sniff_app_traffic(props)
             self._update_monitor(props)
             self._update_session_from_props(props)
-            self._maybe_schedule_session_refresh()
             # Refresh device connection status
             devices = await self.client.async_get_devices()
             for d in devices:
@@ -141,6 +162,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.device = d
                     break
             return props
+        except CloudError as err:
+            raise UpdateFailed(f"Ayla cloud error: {err}") from err
         except Exception as err:
             raise UpdateFailed(f"Error fetching Delonghi data: {err}") from err
 
@@ -197,9 +220,13 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     # Cloud session (app_device_connected)
     #
     # ECAM models require a registered cloud session before commands are
-    # relayed. Logic follows DlghIoT connect(): 4 min cache, adopt foreign
-    # app_id, POST + settle delay on cold connect. Cold path runs in a
-    # background task so button/service handlers return immediately.
+    # relayed. Logic follows DlghIoT connect(): adopt foreign app_id, POST +
+    # settle delay on cold connect only (on-demand before commands). Poll does
+    # NOT register a session — that would block the official Coffee Link app
+    # while HA is idle. After an HA command the machine keeps app_id for ~300 s
+    # (protocol limit); Coffee Link may be temporarily blocked until timeout.
+    # Cold path runs in a background task so button/service handlers return
+    # immediately.
     # ------------------------------------------------------------------ #
 
     def _parse_app_id_value(self, raw: Any) -> int | None:
@@ -216,22 +243,111 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return self._parse_app_id_value(prop.get("value"))
         return None
 
-    async def _read_app_id(self) -> int | None:
-        if self.data:
+    async def _read_app_id(self, *, live: bool = False) -> int | None:
+        if not live and self.data:
             app_id = self._app_id_from_props(self.data)
             if app_id is not None:
                 return app_id
+        app_id, _ok = await self._fetch_app_id_live()
+        return app_id
+
+    async def _fetch_app_id_live(self) -> tuple[int | None, bool]:
+        """Direct GET app_id. Returns (value, fetch_ok); fetch_ok=False on cloud error."""
         try:
-            prop = await self.client.async_get_property(self.device.dsn, APP_ID_PROPERTY)
-        except CloudError:
-            _LOGGER.debug("Could not fetch %s (non-fatal)", APP_ID_PROPERTY, exc_info=True)
-            return None
-        return self._parse_app_id_value(prop.get("value"))
+            prop = await self.client.async_get_property_resilient(
+                self.device.dsn, APP_ID_PROPERTY
+            )
+        except CloudError as err:
+            status = getattr(err, "http_status", None)
+            _LOGGER.warning(
+                "Live app_id fetch failed for dsn=%s (http=%s): %s",
+                self.device.dsn,
+                status,
+                err,
+            )
+            return None, False
+        return self._parse_app_id_value(prop.get("value")), True
+
+    async def _wait_for_session_confirmed(self) -> bool:
+        """Poll app_id until it matches our integration id (DlghIoT connect loop)."""
+        started = time.time()
+        last_progress = started
+        poll_count = 0
+        cloud_errors = 0
+        _LOGGER.debug(
+            "Waiting for cloud session confirm on dsn=%s (timeout=%ds, want app_id=%d)",
+            self.device.dsn,
+            CONNECT_CONFIRM_TIMEOUT,
+            self._integration_app_id,
+        )
+        while time.time() - started < CONNECT_CONFIRM_TIMEOUT:
+            poll_count += 1
+            app_id, fetch_ok = await self._fetch_app_id_live()
+            if not fetch_ok:
+                cloud_errors += 1
+            elif app_id == self._integration_app_id:
+                elapsed = time.time() - started
+                self._session_confirmed = True
+                _LOGGER.info(
+                    "Cloud session confirmed app_id=%d (0x%08x) on dsn=%s after %.1fs "
+                    "(polls=%d, cloud_errors=%d)",
+                    app_id,
+                    app_id & 0xFFFFFFFF,
+                    self.device.dsn,
+                    elapsed,
+                    poll_count,
+                    cloud_errors,
+                )
+                return True
+            await asyncio.sleep(CONNECT_CONFIRM_POLL_INTERVAL)
+            now = time.time()
+            if now - last_progress >= 15:
+                _LOGGER.debug(
+                    "Still waiting for cloud session confirm on dsn=%s (%.0fs/%ds, "
+                    "app_id=%s, want=%d, polls=%d, cloud_errors=%d)",
+                    self.device.dsn,
+                    now - started,
+                    CONNECT_CONFIRM_TIMEOUT,
+                    app_id if fetch_ok else "fetch_failed",
+                    self._integration_app_id,
+                    poll_count,
+                    cloud_errors,
+                )
+                last_progress = now
+        last_app_id, last_ok = await self._fetch_app_id_live()
+        _LOGGER.warning(
+            "Connect POST sent but app_id not confirmed after %ds on dsn=%s "
+            "(last app_id=%s, want=%d, polls=%d, cloud_errors=%d)",
+            CONNECT_CONFIRM_TIMEOUT,
+            self.device.dsn,
+            last_app_id if last_ok else "fetch_failed",
+            self._integration_app_id,
+            poll_count,
+            cloud_errors,
+        )
+        self._session_confirmed = False
+        return False
 
     def _update_session_from_props(self, props: dict[str, Any]) -> None:
         """Parse app_id from poll data; must never break the poll."""
         try:
             app_id = self._app_id_from_props(props)
+            if self.profile.uses_cloud_session and app_id != self._last_seen_app_id:
+                if app_id in (None, 0):
+                    holder = "free"
+                elif app_id == self._default_app_id:
+                    holder = "ha"
+                else:
+                    holder = "foreign"
+                unsigned = (app_id or 0) & 0xFFFFFFFF
+                _LOGGER.debug(
+                    "Cloud session app_id=%s (0x%08x) holder=%s dsn=%s",
+                    app_id if app_id is not None else "None",
+                    unsigned,
+                    holder,
+                    self.device.dsn,
+                )
+                self._last_seen_app_id = app_id
             self._session_confirmed = (
                 app_id is not None and app_id == self._integration_app_id
             )
@@ -248,12 +364,57 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception:  # noqa: BLE001 - diagnostic must not break polling
             _LOGGER.debug("Session parse failed (non-fatal)", exc_info=True)
 
+    def _revert_foreign_app_id_if_session_clear(self, app_id: int | None) -> None:
+        """Before a cold POST, use our own cloud id when no session is held."""
+        if app_id in (None, 0) and self._integration_app_id != self._default_app_id:
+            _LOGGER.info(
+                "No cloud session holder on dsn=%s; reverting to own app_id before connect",
+                self.device.dsn,
+            )
+            self._integration_app_id = self._default_app_id
+            self._last_connect_at = 0
+
+    async def _send_property_command(self, value: str, label: str) -> None:
+        prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
+        self._record_sent(value)
+        _LOGGER.info("Sending %s via %s (len=%d)", label, prop, len(value))
+        _LOGGER.debug("Sending %s via %s: %s", label, prop, value)
+        await self.client.async_set_property_value(self.device.dsn, prop, value)
+        await self.async_request_refresh()
+
+    async def _maybe_send_session_refresh(self) -> None:
+        """DlghIoT refresh(): nudge deep standby before wake when monitor=0."""
+        if self.monitor.get("status") != 0:
+            return
+        value = build_session_refresh_encoded(self._integration_app_id)
+        _LOGGER.info(
+            "Machine in standby; sending session refresh before wake (tail app_id=%d)",
+            self._integration_app_id,
+        )
+        await self._send_property_command(value, "SESSION REFRESH")
+
+    def _wake_command_value(self) -> str:
+        """Build wake frame for ECAM models (session tail). Soul uses main inline path."""
+        value = build_wake_with_session_tail_encoded(self._integration_app_id)
+        _LOGGER.debug(
+            "Wake frame session tail app_id=%d (0x%08x)",
+            self._integration_app_id,
+            self._integration_app_id & 0xFFFFFFFF,
+        )
+        return value
+
+    def _standby_command_value(self) -> str:
+        """Build standby frame for ECAM models (session tail). Soul uses main inline path."""
+        return build_standby_with_session_tail_encoded(self._integration_app_id)
+
     def _session_is_fresh(self, app_id: int | None) -> bool:
         now = time.time()
         if self._last_connect_at + CONNECT_SETTLE_DELAY > now:
             return True
         if self._last_connect_at + CONNECT_REFRESH_INTERVAL > now:
-            if app_id not in (None, 0) and app_id != self._integration_app_id:
+            if app_id == 0:
+                return False
+            if app_id is not None and app_id != self._integration_app_id:
                 return False
             return True
         return False
@@ -267,46 +428,6 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._integration_app_id,
         )
 
-    async def _background_refresh_session(self) -> None:
-        try:
-            async with self._session_connect_lock:
-                await self._post_cloud_session()
-                await asyncio.sleep(CONNECT_SETTLE_DELAY)
-                self._last_connect_at = time.time()
-                _LOGGER.debug(
-                    "Background cloud session refresh completed for dsn=%s",
-                    self.device.dsn,
-                )
-        except Exception:  # noqa: BLE001 - session errors are non-fatal
-            _LOGGER.warning(
-                "Background cloud session refresh failed for dsn=%s (non-fatal)",
-                self.device.dsn,
-                exc_info=True,
-            )
-        finally:
-            self._session_refresh_task = None
-
-    def _maybe_schedule_session_refresh(self) -> None:
-        if not self.profile.uses_cloud_session or not self.connected_property:
-            return
-        if self._integration_app_id != self._default_app_id:
-            # Riding the official app's session (adopted id): never refresh it
-            # on the app's behalf - when it expires, app_id drops to 0 and
-            # _update_session_from_props reverts us to our own id.
-            return
-        app_id = self._app_id_from_props(self.data) if self.data else None
-        if self._session_is_fresh(app_id):
-            _LOGGER.debug("Background cloud session refresh skipped (fresh)")
-            return
-        if self._session_refresh_task is not None and not self._session_refresh_task.done():
-            return
-        if self._session_cold_task is not None and not self._session_cold_task.done():
-            return
-        self._session_refresh_task = self.hass.async_create_background_task(
-            self._background_refresh_session(),
-            "delonghi cloud session refresh",
-        )
-
     async def _cold_connect_then(
         self, send_fn: Callable[[], Awaitable[None]]
     ) -> None:
@@ -316,18 +437,37 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # fresh and go straight to their send. No command is ever dropped.
             async with self._session_connect_lock:
                 if not self._session_is_fresh(None):
+                    app_id = await self._read_app_id(live=True)
+                    self._revert_foreign_app_id_if_session_clear(app_id)
+                    _LOGGER.debug(
+                        "Cold cloud session connect starting dsn=%s (app_id before=%s)",
+                        self.device.dsn,
+                        app_id,
+                    )
                     await self._post_cloud_session()
                     await asyncio.sleep(CONNECT_SETTLE_DELAY)
+                    if not await self._wait_for_session_confirmed():
+                        return
                     self._last_connect_at = time.time()
+                elif not self._session_confirmed:
+                    app_id, fetch_ok = await self._fetch_app_id_live()
+                    if not fetch_ok or app_id != self._integration_app_id:
+                        _LOGGER.warning(
+                            "Warm session cache but app_id=%s (fetch_ok=%s) != %d on dsn=%s; "
+                            "skipping command",
+                            app_id,
+                            fetch_ok,
+                            self._integration_app_id,
+                            self.device.dsn,
+                        )
+                        return
             await send_fn()
-        except Exception:  # noqa: BLE001 - best-effort send after failed connect
+        except Exception:  # noqa: BLE001 - strict: do not send after connect failure
             _LOGGER.warning(
-                "Cold cloud session connect failed for dsn=%s (non-fatal); "
-                "sending command anyway",
+                "Cold cloud session connect failed for dsn=%s; command not sent",
                 self.device.dsn,
                 exc_info=True,
             )
-            await send_fn()
         finally:
             self._session_cold_task = None
 
@@ -339,14 +479,15 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
 
         app_id = await self._read_app_id()
+        self._revert_foreign_app_id_if_session_clear(app_id)
 
         # When Coffee Link already holds the cloud session (app_id != 0 and != ours),
         # we adopt its app_id so HA commands ride the same session instead of fighting
-        # the official app. The adoption is TRANSIENT: we never refresh a foreign
+        # the official app. The adoption is TRANSIENT: we never POST a foreign
         # session, and we revert to our own id once the app releases it (see
-        # _update_session_from_props / _maybe_schedule_session_refresh). If the user
-        # opens Coffee Link while HA is commanding, behaviour is undefined (the app
-        # may hold a LAN lock); close the app first.
+        # _update_session_from_props). If the user opens Coffee Link while HA
+        # is commanding, behaviour is undefined (the app may hold a LAN lock);
+        # close the app first.
         if app_id not in (None, 0) and app_id != self._integration_app_id:
             _LOGGER.info(
                 "Adopting foreign cloud session app_id=%d for dsn=%s",
@@ -363,10 +504,19 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await send_fn()
             return
 
-        _LOGGER.info(
-            "Scheduling cloud session connect for dsn=%s; command in ~%ds",
+        if self._session_cold_task and not self._session_cold_task.done():
+            _LOGGER.warning(
+                "Cloud session connect already in progress for dsn=%s; "
+                "ignoring duplicate command (confirm timeout=%ds)",
+                self.device.dsn,
+                CONNECT_CONFIRM_TIMEOUT,
+            )
+            return
+
+        _LOGGER.debug(
+            "Scheduling cloud session connect for dsn=%s (confirm timeout=%ds)",
             self.device.dsn,
-            CONNECT_SETTLE_DELAY,
+            CONNECT_CONFIRM_TIMEOUT,
         )
         # Each command gets its own task; the connect lock serializes them, so
         # commands pressed during a cold connect are queued, not dropped.
@@ -477,15 +627,24 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # session-refresh packet (e.g. params 03 02) stored as the wake frame
         # would otherwise be replayed forever. Drop it so a real power-on from
         # the app re-teaches it.
-        if self.learned_wake_frame is not None and not is_wake_power_frame(
-            decode_command(self.learned_wake_frame)
-        ):
-            _LOGGER.warning(
-                "Discarding persisted wake frame (not a real power-on): %s. "
-                "Power the machine on once from the official app to re-learn it.",
-                self.learned_wake_frame,
-            )
-            self.learned_wake_frame = None
+        if self.learned_wake_frame is not None:
+            if self.profile.learns_from_app:
+                if not validate_replayed_wake_frame(
+                    replay_with_timestamp(self.learned_wake_frame)
+                ):
+                    _LOGGER.warning(
+                        "Discarding persisted wake frame (integrity check failed): %s. "
+                        "Power the machine on once from the official app to re-learn it.",
+                        self.learned_wake_frame,
+                    )
+                    self.learned_wake_frame = None
+            elif not is_wake_power_frame(decode_command(self.learned_wake_frame)):
+                _LOGGER.warning(
+                    "Discarding persisted wake frame (not a real power-on): %s. "
+                    "Power the machine on once from the official app to re-learn it.",
+                    self.learned_wake_frame,
+                )
+                self.learned_wake_frame = None
         total = (
             len(self.learned_start_frames)
             + len(self.learned_stop_frames)
@@ -633,25 +792,33 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_send_wake(self) -> None:
         """Send the WAKE / power-on command to bring the machine out of standby."""
-        from .command_builder import build_wake_encoded
+        if not self.profile.uses_cloud_session:
+
+            async def _do() -> None:
+                value = self.profile.wake_value(self.learned_wake_frame)
+                if value is None:
+                    value = build_wake_encoded()
+                    _LOGGER.warning(
+                        "No learned wake frame for this %s yet. Power the machine on once "
+                        "from the official Coffee Link app so Home Assistant can capture "
+                        "and replay it. Sending a best-effort synthesized wake meanwhile "
+                        "(the machine will likely ignore it - it lacks the device "
+                        "signature the app appends).",
+                        self.profile.label,
+                    )
+                self._record_sent(value)
+                prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
+                _LOGGER.info("Sending WAKE cmd via %s: %s", prop, value)
+                await self.client.async_set_property_value(self.device.dsn, prop, value)
+                await self.async_request_refresh()
+
+            await self._with_cloud_session(_do)
+            return
 
         async def _do() -> None:
-            value = self.profile.wake_value(self.learned_wake_frame)
-            if value is None:
-                value = build_wake_encoded()
-                _LOGGER.warning(
-                    "No learned wake frame for this %s yet. Power the machine on once "
-                    "from the official Coffee Link app so Home Assistant can capture "
-                    "and replay it. Sending a best-effort synthesized wake meanwhile "
-                    "(the machine will likely ignore it - it lacks the device "
-                    "signature the app appends).",
-                    self.profile.label,
-                )
-            self._record_sent(value)
-            prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-            _LOGGER.info("Sending WAKE cmd via %s: %s", prop, value)
-            await self.client.async_set_property_value(self.device.dsn, prop, value)
-            await self.async_request_refresh()
+            await self._maybe_send_session_refresh()
+            value = self._wake_command_value()
+            await self._send_property_command(value, "WAKE cmd")
 
         await self._with_cloud_session(_do)
 
@@ -677,24 +844,31 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         capture. Validated live on the reference Soul; on learn-and-replay
         models the per-device signature from a learned frame is appended.
         """
-        from .command_builder import build_standby_encoded
+        if not self.profile.uses_cloud_session:
+
+            async def _do() -> None:
+                value = self.profile.standby_value(self._learned_device_signature())
+                if value is None:
+                    value = build_standby_encoded()
+                    _LOGGER.warning(
+                        "No learned frame for this %s yet, so the standby command is "
+                        "sent without the device signature and the machine may ignore "
+                        "it. Trigger any command once from the official Coffee Link "
+                        "app (e.g. power-on) so Home Assistant can learn the signature.",
+                        self.profile.label,
+                    )
+                self._record_sent(value)
+                prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
+                _LOGGER.info("Sending STANDBY cmd via %s: %s", prop, value)
+                await self.client.async_set_property_value(self.device.dsn, prop, value)
+                await self.async_request_refresh()
+
+            await self._with_cloud_session(_do)
+            return
 
         async def _do() -> None:
-            value = self.profile.standby_value(self._learned_device_signature())
-            if value is None:
-                value = build_standby_encoded()
-                _LOGGER.warning(
-                    "No learned frame for this %s yet, so the standby command is "
-                    "sent without the device signature and the machine may ignore "
-                    "it. Trigger any command once from the official Coffee Link "
-                    "app (e.g. power-on) so Home Assistant can learn the signature.",
-                    self.profile.label,
-                )
-            self._record_sent(value)
-            prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-            _LOGGER.info("Sending STANDBY cmd via %s: %s", prop, value)
-            await self.client.async_set_property_value(self.device.dsn, prop, value)
-            await self.async_request_refresh()
+            value = self._standby_command_value()
+            await self._send_property_command(value, "STANDBY cmd")
 
         await self._with_cloud_session(_do)
 

--- a/custom_components/delonghi_coffeelink/sensor.py
+++ b/custom_components/delonghi_coffeelink/sensor.py
@@ -12,8 +12,18 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import COUNTER_SENSORS, DOMAIN, INFO_SENSORS, MANUFACTURER
+from .ayla_client import normalize_signed_app_id
+from .const import (
+    APP_ID_PROPERTY,
+    COUNTER_SENSORS,
+    DOMAIN,
+    INFO_SENSORS,
+    INTEGRATION_CLOUD_APP_ID,
+    MANUFACTURER,
+)
 from .coordinator import DelonghiCoordinator
+
+_HA_CLOUD_SESSION_APP_ID = normalize_signed_app_id(INTEGRATION_CLOUD_APP_ID)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,6 +72,8 @@ async def async_setup_entry(
         entities.append(DelonghiConnectionSensor(coord))
         entities.append(DelonghiMachineStatusSensor(coord))
         entities.append(DelonghiLastCommandSensor(coord))
+        if coord.profile.uses_cloud_session and APP_ID_PROPERTY in (coord.data or {}):
+            entities.append(DelonghiCloudSessionAppIdSensor(coord))
     async_add_entities(entities)
 
 
@@ -197,6 +209,55 @@ class DelonghiMachineStatusSensor(_Base):
         for key in ("status", "progress", "action", "accessory", "error"):
             if key in monitor:
                 attrs[key] = monitor[key]
+        return attrs
+
+
+def _parse_cloud_session_app_id(raw: Any) -> int | None:
+    if raw is None:
+        return None
+    try:
+        return normalize_signed_app_id(int(str(raw).strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _cloud_session_holder(app_id: int | None) -> str:
+    if app_id is None:
+        return "unknown"
+    if app_id == 0:
+        return "free"
+    if app_id == _HA_CLOUD_SESSION_APP_ID:
+        return "ha"
+    return "foreign"
+
+
+class DelonghiCloudSessionAppIdSensor(_Base):
+    """Diagnostic: machine property ``app_id`` (current cloud session holder).
+
+    Unlike ``Last Connected`` (``app_device_connected``), this is the slot the
+    official Coffee Link app checks before connecting — not the last connect POST.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coord: DelonghiCoordinator) -> None:
+        super().__init__(
+            coord, "cloud_session_app_id", "Cloud Session app_id", "mdi:key-chain"
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        prop = (self.coordinator.data or {}).get(APP_ID_PROPERTY)
+        if not isinstance(prop, dict):
+            return None
+        return _parse_cloud_session_app_id(prop.get("value"))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        app_id = self.native_value
+        attrs: dict[str, Any] = {"holder": _cloud_session_holder(app_id)}
+        if app_id is not None:
+            attrs["app_id_hex"] = f"{app_id & 0xFFFFFFFF:08x}"
         return attrs
 
 


### PR DESCRIPTION
### Summary

* Implemented proper cloud session cleanup during entry unload to avoid leaving stale active sessions behind.
* Added resilient property-fetch helpers with retry handling for transient HTTP failures (including intermittent Ayla API errors).
* Added a diagnostic sensor exposing the currently active cloud session app ID, making it easier to identify session ownership and troubleshooting issues.
* Extended the command builder with session-aware helpers for wake/standby related commands.
* Added configuration constants related to cloud session management and HTTP retry behavior.

### Notes

This PR focuses on cloud-session handling, diagnostics, and resilience improvements. It also provides additional tooling for investigating the Eletta Explore deep-standby/cloud-session issues discussed in #1.
