### PR TITLE
feat: add binary sensor support for DeLonghi Coffee Link

### DIFF
--- a/custom_components/delonghi_coffeelink/__init__.py
+++ b/custom_components/delonghi_coffeelink/__init__.py
@@ -27,7 +27,7 @@ from .coordinator import DelonghiCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BUTTON]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
 
 BEVERAGE_KEYS = [b[1] for b in BEVERAGES]
 

--- a/custom_components/delonghi_coffeelink/binary_sensor.py
+++ b/custom_components/delonghi_coffeelink/binary_sensor.py
@@ -1,0 +1,238 @@
+"""Binary sensor platform for DeLonghi Coffee Link (ECAM maintenance alarms)."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import DelonghiCoordinator
+
+_DECALC_PERCENT_PROPERTY = "d512_percentage_to_deca"
+_GROUNDS_COUNTER_PROPERTY = "d551_cnt_coffee_fondi"
+
+
+def _prop_int(data: dict[str, Any] | None, prop_name: str) -> int:
+    if not data:
+        return 0
+    prop = data.get(prop_name)
+    if not isinstance(prop, dict):
+        return 0
+    val = prop.get("value")
+    if val is None:
+        return 0
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    entities: list[BinarySensorEntity] = []
+    for coord in coordinators:
+        if not coord.profile.uses_cloud_session:
+            continue
+        entities.extend(
+            [
+                DelonghiWaterTankBinarySensor(coord),
+                DelonghiWasteContainerBinarySensor(coord),
+                DelonghiDecalcificationBinarySensor(coord),
+                DelonghiFilterBinarySensor(coord),
+            ]
+        )
+    async_add_entities(entities)
+
+
+class _Base(CoordinatorEntity[DelonghiCoordinator], BinarySensorEntity):
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+
+    def __init__(
+        self,
+        coord: DelonghiCoordinator,
+        unique_suffix: str,
+        name: str,
+        icon: str,
+        translation_key: str,
+    ) -> None:
+        super().__init__(coord)
+        self._attr_unique_id = f"{coord.device.dsn}_{unique_suffix}"
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_translation_key = translation_key
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        d = self.coordinator.device
+        return DeviceInfo(
+            identifiers={(DOMAIN, d.dsn)},
+            name=d.name or f"DeLonghi {d.dsn}",
+            manufacturer=MANUFACTURER,
+            model=d.oem_model or d.model,
+            sw_version=d.sw_version,
+            configuration_url=f"http://{d.lan_ip}" if d.lan_ip else None,
+        )
+
+    def _monitor(self) -> dict[str, Any]:
+        return self.coordinator.monitor or {}
+
+    @property
+    def available(self) -> bool:
+        monitor = self._monitor()
+        return super().available and "alarms" in monitor and "error" not in monitor
+
+
+class DelonghiWaterTankBinarySensor(_Base):
+    """Water tank empty or removed (monitor alarm bit 0 / switch bit 4)."""
+
+    def __init__(self, coord: DelonghiCoordinator) -> None:
+        super().__init__(
+            coord,
+            "water_tank_empty",
+            "Water Tank Empty",
+            "mdi:water-off",
+            "water_tank_empty",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return None
+        switches = monitor.get("switches", 0)
+        alarms = monitor["alarms"]
+        # Switch bit 4 set = tank removed (same polarity as waste container bit 3).
+        tank_missing = bool((switches >> 4) & 1)
+        # Empty only: alarm bit 0 or tank missing — not bit 16 (low water warning).
+        return bool((alarms >> 0) & 1 or tank_missing)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return {}
+        switches = monitor.get("switches", 0)
+        alarms = monitor["alarms"]
+        return {
+            "water_tank_present": not bool((switches >> 4) & 1),
+            "water_level_high": bool((switches >> 7) & 1),
+            "water_level_low": bool((switches >> 6) & 1),
+            "water_empty_alarm": bool((alarms >> 0) & 1),
+            "water_low_alarm": bool((alarms >> 16) & 1),
+            "water_tank_alarm": bool((alarms >> 13) & 1),
+        }
+
+
+class DelonghiWasteContainerBinarySensor(_Base):
+    """Waste container full or missing."""
+
+    def __init__(self, coord: DelonghiCoordinator) -> None:
+        super().__init__(
+            coord,
+            "waste_container_full",
+            "Waste Container Full",
+            "mdi:delete-empty",
+            "waste_container_full",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return None
+        alarms = monitor["alarms"]
+        switches = monitor.get("switches", 0)
+        waste_full = bool((alarms >> 1) & 1)
+        container_present = not bool((switches >> 3) & 1)
+        return (not container_present) or waste_full
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return {}
+        switches = monitor.get("switches", 0)
+        alarms = monitor["alarms"]
+        return {
+            "waste_container_present": not bool((switches >> 3) & 1),
+            "waste_full_alarm": bool((alarms >> 1) & 1),
+            "grounds_counter": _prop_int(
+                self.coordinator.data, _GROUNDS_COUNTER_PROPERTY
+            ),
+        }
+
+
+class DelonghiDecalcificationBinarySensor(_Base):
+    """Decalcification needed (alarm bit or percentage threshold)."""
+
+    def __init__(self, coord: DelonghiCoordinator) -> None:
+        super().__init__(
+            coord,
+            "decalcification_needed",
+            "Decalcification Needed",
+            "mdi:coffee-maker",
+            "decalcification_needed",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return None
+        descale_alarm = bool((monitor["alarms"] >> 2) & 1)
+        decalc_percent = _prop_int(self.coordinator.data, _DECALC_PERCENT_PROPERTY)
+        return descale_alarm or decalc_percent >= 90
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return {}
+        return {
+            "descale_alarm": bool((monitor["alarms"] >> 2) & 1),
+            "decalc_percentage": _prop_int(
+                self.coordinator.data, _DECALC_PERCENT_PROPERTY
+            ),
+        }
+
+
+class DelonghiFilterBinarySensor(_Base):
+    """Water filter replacement needed."""
+
+    def __init__(self, coord: DelonghiCoordinator) -> None:
+        super().__init__(
+            coord,
+            "filter_change_needed",
+            "Filter Change Needed",
+            "mdi:filter-variant",
+            "filter_change_needed",
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return None
+        return bool((monitor["alarms"] >> 3) & 1)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        monitor = self._monitor()
+        if "alarms" not in monitor:
+            return {}
+        return {
+            "filter_alarm": bool((monitor["alarms"] >> 3) & 1),
+        }

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -133,32 +133,78 @@ BEVERAGES = [
 # wins (same approach as COMMAND_PROPERTY_CANDIDATES). A sensor whose property is
 # absent on the device is not created (avoids permanently-"unknown" entities).
 #   - PrimaDonna Soul (DL-millcore): d700_tot_bev_b, d701_tot_bev_bw, d703_tot_bev_w, d825_descale_status
-#   - Eletta Explore (DL-striker-cb): d701_tot_bev_b (no milk/water/descale equivalents exposed)
+#   - Eletta Explore (DL-striker-cb): d701_tot_bev_b, d553_water_tot_qty, d512_percentage_to_deca, …
 COUNTER_SENSORS = [
     (["d700_tot_bev_b", "d701_tot_bev_b"], "total_beverages",       "Total Beverages",       "mdi:counter"),
     (["d704_tot_bev_espressi"],            "total_espresso",        "Total Espresso",        "mdi:coffee"),
     (["d701_tot_bev_bw"],                  "total_milk_drinks",     "Total Milk Drinks",     "mdi:cup"),
-    (["d703_tot_bev_w"],                   "total_water",           "Total Water",           "mdi:water"),
+    (["d703_tot_bev_w", "d553_water_tot_qty"], "total_water",       "Total Water",           "mdi:water"),
+    (["d706_tot_id2_coffee"],              "total_coffee",          "Total Coffee",          "mdi:coffee"),
+    (["d707_tot_id3_long"],                "total_long_coffee",     "Total Long Coffee",     "mdi:coffee"),
+    (["d709_id6_americano"],               "total_americano",       "Total Americano",       "mdi:coffee"),
     (["d710_tot_id7_capp"],                "total_cappuccino",      "Total Cappuccino",      "mdi:coffee"),
     (["d711_id8_lattmacc"],                "total_latte_macchiato", "Total Latte Macchiato", "mdi:coffee"),
     (["d712_id9_cafflatt"],                "total_caffelatte",      "Total Caffe Latte",     "mdi:coffee"),
+    (["d713_id10_flatwhite"],              "total_flat_white",      "Total Flat White",      "mdi:coffee"),
     (["d715_id12_hotmilk"],                "total_hot_milk",        "Total Hot Milk",        "mdi:cup"),
     (["d718_id16_hotwater"],               "total_hot_water",       "Total Hot Water",       "mdi:water"),
     (["d719_id22_tea"],                    "total_tea",             "Total Tea",             "mdi:tea"),
     (["d720_tot_id23_coffee_pot"],         "total_coffee_pot",      "Total Coffee Pot",      "mdi:coffee-maker"),
+    (["d731_tot_mug_hot"],                 "total_hot_mug",         "Total Hot Mug",         "mdi:coffee-to-go"),
+    (["d732_tot_mug_cold"],                "total_cold_mug",        "Total Cold Mug",        "mdi:coffee-to-go-outline"),
+    (["d735_iced_bev"],                    "total_iced",            "Total Iced Beverages",  "mdi:cup-water"),
+    (["d738_cold_brew_bev"],               "total_cold_brew",       "Total Cold Brew",       "mdi:coffee-outline"),
     (["d551_cnt_coffee_fondi"],            "grounds_counter",       "Grounds Counter",       "mdi:dots-grid"),
-    (["d825_descale_status"],              "descale_status",        "Descale Status",        "mdi:water-pump"),
+    (["d510_ground_cnt_percentage"],       "grounds_fill_percent",  "Grounds Fill",          "mdi:dots-grid"),
+    (["d825_descale_status", "d512_percentage_to_deca"], "descale_status", "Descale Status", "mdi:water-pump"),
+    (["d552_cnt_calc_tot"],                "decalcifications_done", "Decalcifications Done", "mdi:shimmer"),
+    (["d513_percentage_usage_fltr"],       "filter_usage",          "Filter Usage",          "mdi:filter-variant"),
     (["d556_water_hardness"],              "water_hardness",        "Water Hardness",        "mdi:water-percent"),
 ]
+
+# Counter entity keys exposed only on ECAM models (uses_cloud_session); skipped on Soul.
+ECAM_ONLY_COUNTER_KEYS = frozenset({
+    "total_coffee",
+    "total_long_coffee",
+    "total_americano",
+    "total_flat_white",
+    "total_hot_mug",
+    "total_cold_mug",
+    "total_iced",
+    "total_cold_brew",
+    "grounds_fill_percent",
+    "decalcifications_done",
+    "filter_usage",
+})
+
+# Per-property scaling/units (keyed by resolved Ayla property name, not entity_key).
+PROPERTY_VALUE_SCALE: dict[str, float] = {
+    "d553_water_tot_qty": 1000,  # ml → L
+}
+PROPERTY_UNITS: dict[str, str] = {
+    "d553_water_tot_qty": "L",
+    "d512_percentage_to_deca": "%",
+    "d513_percentage_usage_fltr": "%",
+    "d510_ground_cnt_percentage": "%",
+}
+PROPERTY_MEASUREMENT = frozenset({
+    "d512_percentage_to_deca",
+    "d513_percentage_usage_fltr",
+    "d510_ground_cnt_percentage",
+})
 
 # Info sensors (not counters, general state):
 #   (candidate_property_names, entity_key, display_name, icon)
 INFO_SENSORS = [
     (["software_version"],                         "software_version", "Software Version", "mdi:chip"),
     (["device_connected", "app_device_connected"], "last_connected",   "Last Connected",   "mdi:clock-outline"),
+    (["oem_host_version"],                       "oem_model_info",   "OEM Host Version", "mdi:information-outline"),
 ]
 
-PLATFORMS = ["sensor", "button"]
+# Entity keys in INFO_SENSORS that should be diagnostic (hidden from main UI).
+INFO_DIAGNOSTIC_KEYS = frozenset({"oem_model_info"})
+
+PLATFORMS = ["sensor", "binary_sensor", "button"]
 
 # Service names
 SERVICE_SEND_RAW_COMMAND = "send_raw_command"

--- a/custom_components/delonghi_coffeelink/monitor.py
+++ b/custom_components/delonghi_coffeelink/monitor.py
@@ -56,12 +56,21 @@ def _parse_monitor_contents(contents: bytes) -> dict[str, int]:
     """Extract the monitor fields from the MonitorV2 contents block."""
     if len(contents) < 8:
         raise ValueError("monitor contents too short")
-    return {
+    fields: dict[str, int] = {
         "accessory": contents[0],
         "status": contents[5],
         "action": contents[6],
         "progress": contents[7],
     }
+    if len(contents) >= 13:
+        fields["switches"] = contents[1] | (contents[2] << 8)
+        fields["alarms"] = (
+            contents[3]
+            | (contents[4] << 8)
+            | (contents[8] << 16)
+            | (contents[9] << 24)
+        )
+    return fields
 
 
 def parse_monitor_b64(value_b64: str) -> dict[str, Any]:
@@ -79,13 +88,18 @@ def parse_monitor_b64(value_b64: str) -> dict[str, Any]:
             return {"error": f"not MonitorV2 (id={data[0] if data else '?'})"}
         fields = _parse_monitor_contents(data[2:])
         status = fields["status"]
-        return {
+        result: dict[str, Any] = {
             "status": status,
             "status_name": MACHINE_STATUS.get(status, "unknown"),
             "progress": fields["progress"],
             "action": fields["action"],
             "accessory": fields["accessory"],
         }
+        if "switches" in fields:
+            result["switches"] = fields["switches"]
+        if "alarms" in fields:
+            result["alarms"] = fields["alarms"]
+        return result
     except (ValueError, binascii.Error) as err:
         _LOGGER.debug("Failed to parse monitor blob: %s", err)
         return {"error": str(err)}

--- a/custom_components/delonghi_coffeelink/sensor.py
+++ b/custom_components/delonghi_coffeelink/sensor.py
@@ -1,44 +1,124 @@
 """Sensor platform for DeLonghi Coffee Link."""
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 import logging
+from datetime import datetime
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from .ayla_client import normalize_signed_app_id
 from .const import (
     APP_ID_PROPERTY,
     COUNTER_SENSORS,
     DOMAIN,
+    ECAM_ONLY_COUNTER_KEYS,
+    INFO_DIAGNOSTIC_KEYS,
     INFO_SENSORS,
     INTEGRATION_CLOUD_APP_ID,
     MANUFACTURER,
+    PROPERTY_MEASUREMENT,
+    PROPERTY_UNITS,
+    PROPERTY_VALUE_SCALE,
 )
 from .coordinator import DelonghiCoordinator
 
 _HA_CLOUD_SESSION_APP_ID = normalize_signed_app_id(INTEGRATION_CLOUD_APP_ID)
+_SESSION_TS_MIN = 946684800  # 2000-01-01
+_SESSION_TS_MAX = 4102444800  # 2100-01-01
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def _resolve_property(data: dict[str, Any] | None, candidates: list[str]) -> str | None:
-    """Return the first candidate property name present on the device, else None.
+def _parse_counter_value_legacy(val: Any) -> int | None:
+    """Pre-PR Soul counter parser: plain integers only."""
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        return None
+    if isinstance(val, int):
+        return val
+    try:
+        return int(str(val).strip())
+    except (TypeError, ValueError):
+        return None
 
-    Property names differ across DeLonghi models (e.g. d700_tot_bev_b on Soul vs
-    d701_tot_bev_b on Eletta Explore), so each sensor declares a candidate list.
-    """
+
+def _parse_counter_value(val: Any) -> int | None:
+    """Parse an Ayla counter property value to int (ECAM may use floats/JSON)."""
+    if val is None:
+        return None
+    if isinstance(val, bool):
+        return None
+    if isinstance(val, int):
+        return val
+    if isinstance(val, float):
+        return int(val)
+    if isinstance(val, dict):
+        total = 0
+        for item in val.values():
+            parsed = _parse_counter_value(item)
+            if parsed is not None:
+                total += parsed
+        return total
+    text = str(val).strip()
+    if not text:
+        return 0
+    if text.startswith("{"):
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            payload = None
+        if isinstance(payload, dict):
+            return _parse_counter_value(payload)
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        return int(float(text))
+    except ValueError:
+        return None
+
+
+def _resolve_property(data: dict[str, Any] | None, candidates: list[str]) -> str | None:
+    """Return the first candidate property name present on the device, else None."""
     data = data or {}
     for candidate in candidates:
         if candidate in data:
             return candidate
     return None
+
+
+def _parse_last_connected(value: Any) -> datetime | str | int | float | None:
+    """Decode ECAM session blob (8-byte timestamp+app_id) or return value as-is."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    try:
+        raw = base64.b64decode(value.strip(), validate=True)
+        if len(raw) == 8:
+            ts = int.from_bytes(raw[:4], "big")
+            if _SESSION_TS_MIN <= ts <= _SESSION_TS_MAX:
+                return dt_util.as_local(dt_util.utc_from_timestamp(ts))
+    except (ValueError, binascii.Error):
+        pass
+    return value
 
 
 async def async_setup_entry(
@@ -49,7 +129,10 @@ async def async_setup_entry(
     coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
     entities: list[SensorEntity] = []
     for coord in coordinators:
+        ecam = coord.profile.uses_cloud_session
         for candidates, key, friendly, icon in COUNTER_SENSORS:
+            if key in ECAM_ONLY_COUNTER_KEYS and not ecam:
+                continue
             prop_name = _resolve_property(coord.data, candidates)
             if prop_name is None:
                 _LOGGER.debug(
@@ -61,14 +144,38 @@ async def async_setup_entry(
                 DelonghiCounterSensor(coord, prop_name, key, friendly, icon)
             )
         for candidates, key, friendly, icon in INFO_SENSORS:
-            prop_name = _resolve_property(coord.data, candidates)
+            if key == "oem_model_info" and not ecam:
+                continue
+            if key == "last_connected":
+                lc_candidates = (
+                    ["app_device_connected", "device_connected"]
+                    if ecam
+                    else ["device_connected", "app_device_connected"]
+                )
+                prop_name = _resolve_property(coord.data, lc_candidates)
+            else:
+                prop_name = _resolve_property(coord.data, candidates)
             if prop_name is None:
                 _LOGGER.debug(
                     "Skipping info sensor '%s' for dsn=%s: none of %s present",
                     key, coord.device.dsn, candidates,
                 )
                 continue
-            entities.append(DelonghiInfoSensor(coord, prop_name, key, friendly, icon))
+            if key == "last_connected" and ecam:
+                entities.append(
+                    DelonghiLastConnectedSensor(coord, prop_name, key, friendly, icon)
+                )
+            else:
+                category = (
+                    EntityCategory.DIAGNOSTIC
+                    if key in INFO_DIAGNOSTIC_KEYS
+                    else None
+                )
+                entities.append(
+                    DelonghiInfoSensor(
+                        coord, prop_name, key, friendly, icon, entity_category=category
+                    )
+                )
         entities.append(DelonghiConnectionSensor(coord))
         entities.append(DelonghiMachineStatusSensor(coord))
         entities.append(DelonghiLastCommandSensor(coord))
@@ -100,7 +207,7 @@ class _Base(CoordinatorEntity[DelonghiCoordinator], SensorEntity):
 
 
 class DelonghiCounterSensor(_Base):
-    """Integer counter sensor with TOTAL_INCREASING state class."""
+    """Counter sensor; TOTAL_INCREASING by default, MEASUREMENT for ECAM percentages."""
 
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
@@ -115,25 +222,23 @@ class DelonghiCounterSensor(_Base):
         super().__init__(coord, key, friendly, icon)
         self._prop_name = prop_name
         self._logged_unparseable = False
+        self._ecam_parsing = coord.profile.uses_cloud_session
+        if prop_name in PROPERTY_UNITS:
+            self._attr_native_unit_of_measurement = PROPERTY_UNITS[prop_name]
+        if prop_name in PROPERTY_MEASUREMENT:
+            self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> int | float | None:
         prop = (self.coordinator.data or {}).get(self._prop_name)
         if not prop:
             return None
         val = prop.get("value")
-        if val is None:
-            return None
-        # Soul exposes counters as plain integers. Some models may wrap the value
-        # differently (e.g. a base64 binary blob); don't guess the layout - parse
-        # what we can and log the raw value once so the format can be confirmed.
-        if isinstance(val, bool):
-            return None
-        if isinstance(val, int):
-            return val
-        try:
-            return int(str(val).strip())
-        except (TypeError, ValueError):
+        if self._ecam_parsing:
+            numeric = _parse_counter_value(val)
+        else:
+            numeric = _parse_counter_value_legacy(val)
+        if numeric is None:
             if not self._logged_unparseable:
                 self._logged_unparseable = True
                 _LOGGER.warning(
@@ -146,14 +251,40 @@ class DelonghiCounterSensor(_Base):
                     val,
                 )
             return None
+        scale = PROPERTY_VALUE_SCALE.get(self._prop_name)
+        if scale:
+            return round(numeric / scale, 1)
+        return numeric
 
 
 class DelonghiInfoSensor(_Base):
-    """Generic info sensor (version string, timestamp, etc.).
+    """Generic info sensor (version string, serial, etc.)."""
 
-    The concrete property name is resolved per-model at setup time (see
-    INFO_SENSORS candidate lists), so no name fallback is needed here.
-    """
+    def __init__(
+        self,
+        coord: DelonghiCoordinator,
+        prop_name: str,
+        key: str,
+        friendly: str,
+        icon: str,
+        *,
+        entity_category: EntityCategory | None = None,
+    ) -> None:
+        super().__init__(coord, key, friendly, icon)
+        self._prop_name = prop_name
+        if entity_category is not None:
+            self._attr_entity_category = entity_category
+
+    @property
+    def native_value(self) -> Any:
+        prop = (self.coordinator.data or {}).get(self._prop_name)
+        if not prop:
+            return None
+        return prop.get("value")
+
+
+class DelonghiLastConnectedSensor(_Base):
+    """Last connect time for ECAM models (8-byte app_device_connected session blob)."""
 
     def __init__(
         self,
@@ -166,12 +297,42 @@ class DelonghiInfoSensor(_Base):
         super().__init__(coord, key, friendly, icon)
         self._prop_name = prop_name
 
-    @property
-    def native_value(self) -> Any:
+    def _raw_value(self) -> Any:
         prop = (self.coordinator.data or {}).get(self._prop_name)
         if not prop:
             return None
         return prop.get("value")
+
+    @property
+    def native_value(self) -> datetime | str | int | float | None:
+        return _parse_last_connected(self._raw_value())
+
+    @property
+    def device_class(self) -> SensorDeviceClass | None:
+        parsed = _parse_last_connected(self._raw_value())
+        if isinstance(parsed, datetime):
+            return SensorDeviceClass.TIMESTAMP
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        raw = self._raw_value()
+        if not isinstance(raw, str):
+            return {}
+        try:
+            blob = base64.b64decode(raw.strip(), validate=True)
+            if len(blob) != 8:
+                return {}
+            ts = int.from_bytes(blob[:4], "big")
+            if not (_SESSION_TS_MIN <= ts <= _SESSION_TS_MAX):
+                return {}
+            app_id = int.from_bytes(blob[4:8], "big", signed=True)
+        except (ValueError, binascii.Error):
+            return {}
+        return {
+            "connected_app_id": app_id,
+            "connected_app_id_hex": f"{app_id & 0xFFFFFFFF:08x}",
+        }
 
 
 class DelonghiConnectionSensor(_Base):
@@ -186,11 +347,7 @@ class DelonghiConnectionSensor(_Base):
 
 
 class DelonghiMachineStatusSensor(_Base):
-    """Machine operational state decoded from ``d302_monitor_machine``
-    (standby, ready, rinsing, ...). Contributed via PR #5 (@TischenkoArseny,
-    based on the DlghIoT client). ``None``/unknown if the blob doesn't parse
-    on this model - the parse error is surfaced as an attribute.
-    """
+    """Machine operational state decoded from ``d302_monitor_machine``."""
 
     def __init__(self, coord: DelonghiCoordinator) -> None:
         super().__init__(coord, "machine_status", "Machine Status", "mdi:coffee-maker")
@@ -209,6 +366,11 @@ class DelonghiMachineStatusSensor(_Base):
         for key in ("status", "progress", "action", "accessory", "error"):
             if key in monitor:
                 attrs[key] = monitor[key]
+        if self.coordinator.profile.uses_cloud_session:
+            if "switches" in monitor:
+                attrs["switches"] = f"0x{monitor['switches']:04X}"
+            if "alarms" in monitor:
+                attrs["alarms"] = f"0x{monitor['alarms']:08X}"
         return attrs
 
 
@@ -232,11 +394,7 @@ def _cloud_session_holder(app_id: int | None) -> str:
 
 
 class DelonghiCloudSessionAppIdSensor(_Base):
-    """Diagnostic: machine property ``app_id`` (current cloud session holder).
-
-    Unlike ``Last Connected`` (``app_device_connected``), this is the slot the
-    official Coffee Link app checks before connecting — not the last connect POST.
-    """
+    """Diagnostic: machine property ``app_id`` (current cloud session holder)."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -262,14 +420,7 @@ class DelonghiCloudSessionAppIdSensor(_Base):
 
 
 class DelonghiLastCommandSensor(_Base):
-    """Diagnostic: last command seen on the binary channel.
-
-    Surfaces the command sniffer (see coordinator). When the official Coffee
-    Link app sends a command, its exact base64 bytes appear here as the state,
-    decoded in the attributes - including ``matches_integration`` which tells
-    whether the app's bytes match what this integration would generate. This is
-    the ground-truth needed to debug models where commands are silently ignored.
-    """
+    """Diagnostic: last command seen on the binary channel."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -283,7 +434,6 @@ class DelonghiLastCommandSensor(_Base):
         rec = self.coordinator.last_captured_command
         if not rec:
             return None
-        # Frames are short (<= ~24 base64 chars), well within the 255 limit.
         return rec.get("raw_b64")
 
     @property

--- a/custom_components/delonghi_coffeelink/strings.json
+++ b/custom_components/delonghi_coffeelink/strings.json
@@ -19,5 +19,21 @@
     "abort": {
       "already_configured": "This account is already configured."
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "water_tank_empty": {
+        "name": "Water tank empty"
+      },
+      "waste_container_full": {
+        "name": "Waste container full"
+      },
+      "decalcification_needed": {
+        "name": "Decalcification needed"
+      },
+      "filter_change_needed": {
+        "name": "Filter change needed"
+      }
+    }
   }
 }

--- a/custom_components/delonghi_coffeelink/translations/en.json
+++ b/custom_components/delonghi_coffeelink/translations/en.json
@@ -19,5 +19,21 @@
     "abort": {
       "already_configured": "This account is already configured."
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "water_tank_empty": {
+        "name": "Water tank empty"
+      },
+      "waste_container_full": {
+        "name": "Waste container full"
+      },
+      "decalcification_needed": {
+        "name": "Decalcification needed"
+      },
+      "filter_change_needed": {
+        "name": "Filter change needed"
+      }
+    }
   }
 }

--- a/custom_components/delonghi_coffeelink/translations/fr.json
+++ b/custom_components/delonghi_coffeelink/translations/fr.json
@@ -19,5 +19,21 @@
     "abort": {
       "already_configured": "Ce compte est deja configure."
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "water_tank_empty": {
+        "name": "Reservoir d'eau vide"
+      },
+      "waste_container_full": {
+        "name": "Bac a marc plein"
+      },
+      "decalcification_needed": {
+        "name": "Decalcification necessaire"
+      },
+      "filter_change_needed": {
+        "name": "Changement de filtre necessaire"
+      }
+    }
   }
 }


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h1>Extend Eletta Explore sensor coverage and maintenance diagnostics</h1><h2>Background</h2><p>This PR is primarily motivated by the investigation in Issue #7:</p><p><a href="https://github.com/actabi/delonghi_coffeelink/issues/7">https://github.com/actabi/delonghi_coffeelink/issues/7</a></p><p>Several Eletta Explore users reported <code inline="">N/A</code>, <code inline="">Unknown</code>, or missing values for maintenance status and drink counters. During the investigation it became clear that the integration was not exposing a number of ECAM-specific datapoints already available on the device, and some MonitorV2 fields (<code inline="">switches</code>, <code inline="">alarms</code>) were not being parsed.</p><p>The goal of this PR is to improve diagnostics and maintenance visibility for Eletta Explore (<code inline="">DL-striker-cb</code>) while keeping PrimaDonna Soul (<code inline="">DL-millcore</code>) behavior unchanged.</p><hr><h2>New binary_sensor platform (Eletta only)</h2><p>Adds four maintenance binary sensors derived from <code inline="">d302_monitor_machine</code>:</p><h3>Water Tank Empty</h3><p>Turns on when:</p><ul><li><p>alarm bit <code inline="">0</code> is set (tank empty), or</p></li><li><p>switch bit <code inline="">4</code> indicates the tank is removed.</p></li></ul><p>Low-water related bits are exposed as diagnostic attributes only and do not affect the entity state.</p><h3>Waste Container Full</h3><p>Turns on when:</p><ul><li><p>alarm bit <code inline="">1</code> is set, or</p></li><li><p>switch bit <code inline="">3</code> indicates the grounds container is removed.</p></li></ul><h3>Decalcification Needed</h3><p>Turns on when:</p><ul><li><p>alarm bit <code inline="">2</code> is set, or</p></li><li><p><code inline="">d512_percentage_to_deca &gt;= 90</code>.</p></li></ul><h3>Filter Change Needed</h3><p>Turns on when:</p><ul><li><p>alarm bit <code inline="">3</code> is set.</p></li></ul><p>These entities are created only for Eletta-style models.</p><hr><h2>Sensor improvements</h2><h3>Fixed and added counters</h3><p>Added support for additional ECAM counters using skip-if-absent behavior:</p><ul><li><p>Total Water (<code inline="">d553_water_tot_qty</code>, converted to liters)</p></li><li><p>Descale Status (<code inline="">d512_percentage_to_deca</code>)</p></li><li><p>Coffee</p></li><li><p>Long Coffee</p></li><li><p>Americano</p></li><li><p>Flat White</p></li><li><p>Hot Mug</p></li><li><p>Cold Mug</p></li><li><p>Iced</p></li><li><p>Cold Brew</p></li></ul><p>Additional maintenance metrics:</p><ul><li><p>Grounds fill percentage</p></li><li><p>Decalcifications completed</p></li><li><p>Filter usage percentage</p></li></ul><h3>Improved counter parsing</h3><p>The Eletta parser now correctly handles:</p><ul><li><p>float-like strings such as <code inline="">"0.0"</code></p></li><li><p>empty values</p></li><li><p>JSON object values used by certain iced/cold-brew counters</p></li></ul><p>This resolves several <code inline="">Unknown</code> / <code inline="">N/A</code> values reported in Issue #7.</p><hr><h2>Last Connected improvements</h2><p>For Eletta, <code inline="">Last Connected</code> now decodes the 8-byte <code inline="">app_device_connected</code> blob into a timestamp and exposes the connected app ID as an attribute.</p><hr><h2>Machine Status diagnostics</h2><p><code inline="">Machine Status</code> now exposes raw:</p><ul><li><p>switches</p></li><li><p>alarms</p></li></ul><p>values as hexadecimal diagnostic attributes, making troubleshooting significantly easier.</p><hr><h2>OEM Host Version</h2><p>Adds <code inline="">OEM Host Version</code> as a diagnostic entity.</p><p>The previous serial-number entity has been removed because <code inline="">d270_serialnumber</code> returns raw base64 data rather than a meaningful user-facing serial number.</p><hr><h2>MonitorV2 parsing</h2><p><code inline="">monitor.py</code> now parses both:</p><ul><li><p>switches</p></li><li><p>alarms</p></li></ul><p>from MonitorV2 using the DlghIoT layout.</p><p>Without this parsing, the maintenance binary sensors remain unavailable.</p><hr><h2>Soul isolation</h2><p>Soul behavior remains unchanged.</p><p>All new code paths are enabled only for Eletta-style models.</p><p>Specifically:</p>
Feature | Soul | Eletta
-- | -- | --
Last Connected | Existing implementation | app_device_connected decoding
Counter parser | Legacy parser | Extended parser
Machine Status hex attributes | No | Yes
OEM Host Version | No | Yes
ECAM-only counters | No | Yes
Maintenance binary sensors | No | Yes

<p>This PR does <strong>not</strong> modify:</p><ul><li><p>coordinator logic</p></li><li><p>button entities</p></li><li><p>Ayla client</p></li><li><p>command builder</p></li><li><p>command sending</p></li><li><p>cloud-session handling</p></li></ul><hr><h2>Translations</h2><p>Added translation strings for the new maintenance binary sensors in:</p><ul><li><p><code inline="">strings.json</code></p></li><li><p><code inline="">en.json</code></p></li><li><p><code inline="">fr.json</code></p></li></ul><hr><h2>Tested on</h2><pre><code class="language-text">OEM Model: DL-striker-cb
DSN: AC000W033438064
</code></pre><p>Verified:</p><ul><li><p>Total Iced / Cold Brew now show <code inline="">0</code> instead of <code inline="">Unknown</code></p></li><li><p>Water Tank Empty remains off with a full tank</p></li><li><p>Maintenance sensors update correctly from monitor data</p></li><li><p>Raw serial-number entity is no longer exposed</p></li><li><p>Changes take effect after reloading the integration</p></li></ul></body></html><!--EndFragment-->
</body>
</html>