### PR TITLE
Complete Czech localization and correct water-counter units

### DIFF
--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -97,6 +97,14 @@ MACHINE_STATUS = {
     17: "preparing_milk_alt",
     29: "unknown",
 }
+MACHINE_STATUS_OPTIONS = tuple(dict.fromkeys(MACHINE_STATUS.values()))
+CONNECTION_STATUS_OPTIONS = ("online", "offline", "unknown")
+
+
+def normalize_connection_status(value: object) -> str:
+    """Return a stable Home Assistant enum key for an Ayla connection value."""
+    normalized = str(value).strip().lower() if value is not None else ""
+    return normalized if normalized in CONNECTION_STATUS_OPTIONS else "unknown"
 
 # Default recipe params (from captured hot water command)
 # Bytes: temp_flag, reserved, quantity_low, quantity_high?, recipe_type, ???

--- a/custom_components/delonghi_coffeelink/counters.py
+++ b/custom_components/delonghi_coffeelink/counters.py
@@ -51,6 +51,14 @@ def parse_counter_value(val: Any) -> int | None:
         return None
 
 
+def parse_water_volume_liters(val: Any) -> float | None:
+    """Convert a De'Longhi water-volume counter from millilitres to litres."""
+    milliliters = parse_counter_value(val)
+    if milliliters is None:
+        return None
+    return round(milliliters / 1000, 3)
+
+
 def counter_breakdown(val: Any) -> dict | None:
     """Return the per-recipe JSON breakdown of a counter value, else ``None``.
 

--- a/custom_components/delonghi_coffeelink/sensor.py
+++ b/custom_components/delonghi_coffeelink/sensor.py
@@ -10,22 +10,25 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EntityCategory, UnitOfVolume
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .ayla_client import normalize_signed_app_id
-from .counters import counter_breakdown, parse_counter_value
+from .counters import counter_breakdown, parse_counter_value, parse_water_volume_liters
 from .const import (
     APP_ID_PROPERTY,
+    CONNECTION_STATUS_OPTIONS,
     COUNTER_SENSORS,
     DOMAIN,
     INFO_SENSORS,
     INTEGRATION_CLOUD_APP_ID,
     MANUFACTURER,
+    MACHINE_STATUS_OPTIONS,
+    normalize_connection_status,
 )
 from .coordinator import DelonghiCoordinator
 
@@ -119,10 +122,20 @@ class DelonghiCounterSensor(_Base):
     ) -> None:
         super().__init__(coord, key, icon)
         self._prop_name = prop_name
+        self._key = key
         self._logged_unparseable = False
+        if key in {"water_total_quantity", "water_filter_quantity"}:
+            self._attr_device_class = SensorDeviceClass.WATER
+            self._attr_native_unit_of_measurement = UnitOfVolume.LITERS
+            self._attr_suggested_display_precision = 3
+            self._attr_state_class = (
+                SensorStateClass.TOTAL
+                if key == "water_total_quantity"
+                else SensorStateClass.TOTAL_INCREASING
+            )
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> int | float | None:
         prop = (self.coordinator.data or {}).get(self._prop_name)
         if not prop:
             return None
@@ -133,7 +146,11 @@ class DelonghiCounterSensor(_Base):
         # some as a JSON object of per-recipe sub-counts. parse_counter_value
         # handles both; an unparseable scalar yields None and is logged once so
         # the format can be reported and the parser extended.
-        result = parse_counter_value(val)
+        result = (
+            parse_water_volume_liters(val)
+            if self._key in {"water_total_quantity", "water_filter_quantity"}
+            else parse_counter_value(val)
+        )
         if result is None and not self._logged_unparseable:
             self._logged_unparseable = True
             _LOGGER.warning(
@@ -192,10 +209,12 @@ class DelonghiConnectionSensor(_Base):
 
     def __init__(self, coord: DelonghiCoordinator) -> None:
         super().__init__(coord, "connection_status", "mdi:cloud")
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_options = list(CONNECTION_STATUS_OPTIONS)
 
     @property
     def native_value(self) -> str:
-        return self.coordinator.device.connection_status
+        return normalize_connection_status(self.coordinator.device.connection_status)
 
 
 class DelonghiMachineStatusSensor(_Base):
@@ -207,12 +226,14 @@ class DelonghiMachineStatusSensor(_Base):
 
     def __init__(self, coord: DelonghiCoordinator) -> None:
         super().__init__(coord, "machine_status", "mdi:coffee-maker")
+        self._attr_device_class = SensorDeviceClass.ENUM
+        self._attr_options = list(MACHINE_STATUS_OPTIONS)
 
     @property
     def native_value(self) -> str | None:
         monitor = self.coordinator.monitor or {}
         if "error" in monitor:
-            return None
+            return "unknown"
         return monitor.get("status_name")
 
     @property

--- a/custom_components/delonghi_coffeelink/services.yaml
+++ b/custom_components/delonghi_coffeelink/services.yaml
@@ -1,14 +1,11 @@
 start_beverage:
-  name: Start Beverage
-  description: Start brewing a specific beverage on the connected DeLonghi machine.
   fields:
     beverage:
-      name: Beverage
-      description: Beverage key (espresso, cappuccino, hot_water, tea, etc.)
       required: true
       example: hot_water
       selector:
         select:
+          translation_key: beverage
           options:
             - espresso
             - coffee
@@ -33,16 +30,13 @@ start_beverage:
             - brew_over_ice
 
 stop_beverage:
-  name: Stop Beverage
-  description: Send a stop command for the given beverage.
   fields:
     beverage:
-      name: Beverage
-      description: Beverage key
       required: true
       example: hot_water
       selector:
         select:
+          translation_key: beverage
           options:
             - espresso
             - coffee
@@ -52,12 +46,8 @@ stop_beverage:
             - americano
 
 send_raw_command:
-  name: Send Raw Command
-  description: Send a raw base64-encoded binary command to data_request (advanced).
   fields:
     value_base64:
-      name: Command (base64)
-      description: Base64 encoding of the binary command bytes.
       required: true
       example: DQ2D8BABDwD6GwEGgSRp6Myg
       selector:

--- a/custom_components/delonghi_coffeelink/strings.json
+++ b/custom_components/delonghi_coffeelink/strings.json
@@ -131,10 +131,31 @@
         "name": "Last Connected"
       },
       "connection_status": {
-        "name": "Connection Status"
+        "name": "Cloud Connection",
+        "state": {
+          "online": "Connected",
+          "offline": "Disconnected",
+          "unknown": "Unknown"
+        }
       },
       "machine_status": {
-        "name": "Machine Status"
+        "name": "Machine Status",
+        "state": {
+          "standby": "Standby",
+          "waking_up": "Waking up",
+          "going_to_sleep": "Going to standby",
+          "descaling": "Descaling",
+          "preparing_steam": "Preparing steam",
+          "recovering": "Recovering",
+          "ready": "Ready",
+          "rinsing": "Rinsing",
+          "preparing_milk": "Preparing milk",
+          "dispensing_hot_water": "Dispensing hot water",
+          "cleaning_milk": "Cleaning milk system",
+          "preparing_chocolate": "Preparing chocolate",
+          "preparing_milk_alt": "Preparing milk",
+          "unknown": "Unknown"
+        }
       },
       "cloud_session_app_id": {
         "name": "Cloud Session app_id"
@@ -232,6 +253,65 @@
       },
       "filter_change_needed": {
         "name": "Filter change needed"
+      }
+    }
+  },
+  "services": {
+    "start_beverage": {
+      "name": "Start beverage",
+      "description": "Start preparing a beverage on the selected De'Longhi coffee machine.",
+      "fields": {
+        "beverage": {
+          "name": "Beverage",
+          "description": "Beverage recipe to prepare."
+        }
+      }
+    },
+    "stop_beverage": {
+      "name": "Stop beverage",
+      "description": "Stop preparation of the selected beverage.",
+      "fields": {
+        "beverage": {
+          "name": "Beverage",
+          "description": "Beverage recipe whose preparation should be stopped."
+        }
+      }
+    },
+    "send_raw_command": {
+      "name": "Send raw command",
+      "description": "Send an advanced base64-encoded binary command to the coffee machine.",
+      "fields": {
+        "value_base64": {
+          "name": "Command (base64)",
+          "description": "Base64 representation of the binary command bytes."
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "espresso": "Espresso",
+        "coffee": "Coffee",
+        "long_coffee": "Long Coffee",
+        "double_espresso": "Double Espresso",
+        "doppio": "Doppio+",
+        "americano": "Americano",
+        "cappuccino": "Cappuccino",
+        "latte_macchiato": "Latte Macchiato",
+        "caffelatte": "Caffe Latte",
+        "flat_white": "Flat White",
+        "espresso_macchiato": "Espresso Macchiato",
+        "hot_milk": "Hot Milk",
+        "cappuccino_doppio": "Cappuccino Doppio+",
+        "cappuccino_reverse": "Cappuccino Reverse",
+        "hot_water": "Hot Water",
+        "tea": "Tea",
+        "coffee_pot": "Coffee Pot",
+        "cortado": "Cortado",
+        "long_black": "Long Black",
+        "mug_to_go": "Mug to Go",
+        "brew_over_ice": "Brew Over Ice"
       }
     }
   }

--- a/custom_components/delonghi_coffeelink/translations/cs.json
+++ b/custom_components/delonghi_coffeelink/translations/cs.json
@@ -1,216 +1,183 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "title": "De'Longhi Coffee Link",
+        "description": "Zadejte přihlašovací údaje k účtu Coffee Link. Použijte stejné údaje jako v mobilní aplikaci Coffee Link.",
+        "data": {
+          "email": "E-mail",
+          "password": "Heslo"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Neplatný e-mail nebo heslo.",
+      "cannot_connect": "Nepodařilo se připojit ke cloudu De'Longhi.",
+      "no_devices": "U tohoto účtu nebyl nalezen žádný kávovar De'Longhi.",
+      "unknown": "Došlo k neočekávané chybě."
+    },
+    "abort": {
+      "already_configured": "Tento účet je již nakonfigurován."
+    }
+  },
   "entity": {
     "sensor": {
-      "total_beverages": {
-        "name": "Celkem Nápoje"
-      },
-      "total_espresso": {
-        "name": "Celkem Espresso"
-      },
-      "total_milk_drinks": {
-        "name": "Celkem Mléčné nápoje"
-      },
-      "total_water": {
-        "name": "Celkem Voda"
-      },
-      "total_espresso_alt": {
-        "name": "Celkem Espresso Alt"
-      },
-      "total_coffee": {
-        "name": "Celkem Coffee"
-      },
-      "total_long_coffee": {
-        "name": "Celkem Long Coffee"
-      },
-      "total_doppio": {
-        "name": "Celkem Doppio+"
-      },
-      "total_americano": {
-        "name": "Celkem Americano"
-      },
-      "total_cappuccino": {
-        "name": "Celkem Cappuccino"
-      },
-      "total_latte_macchiato": {
-        "name": "Celkem Latte Macchiato"
-      },
-      "total_caffelatte": {
-        "name": "Celkem Caffe Latte"
-      },
-      "total_flat_white": {
-        "name": "Celkem Flat White"
-      },
-      "total_espresso_macchiato": {
-        "name": "Celkem Espresso Macchiato"
-      },
-      "total_hot_milk": {
-        "name": "Celkem Hot Milk"
-      },
-      "total_cappuccino_doppio": {
-        "name": "Celkem Cappuccino Doppio+"
-      },
-      "total_cappuccino_reverse": {
-        "name": "Celkem Cappuccino Reverse"
-      },
-      "total_hot_water": {
-        "name": "Celkem Hot Voda"
-      },
-      "total_tea": {
-        "name": "Celkem Tea"
-      },
-      "total_coffee_pot": {
-        "name": "Celkem Konvice kávy"
-      },
-      "total_brew_over_ice": {
-        "name": "Celkem Zchlazeno ledem"
-      },
-      "total_mug_hot": {
-        "name": "Celkem Horké do hrnku"
-      },
-      "total_mug_cold": {
-        "name": "Celkem Studené do hrnku"
-      },
-      "total_iced_bev": {
-        "name": "Celkem Ledové Nápoje"
-      },
-      "total_mug_bev": {
-        "name": "Celkem Hrnek Nápoje"
-      },
-      "total_mug_iced_bev": {
-        "name": "Celkem Hrnek Ledové Nápoje"
-      },
-      "total_cold_brew_bev": {
-        "name": "Celkem Cold Brew Nápoje"
-      },
-      "grounds_counter": {
-        "name": "Počítadlo sedliny"
-      },
-      "total_descales": {
-        "name": "Celkem Odvápnění"
-      },
-      "water_total_quantity": {
-        "name": "Voda Celkem Množství"
-      },
-      "total_filters_used": {
-        "name": "Celkem Použitých filtrů"
-      },
-      "water_filter_quantity": {
-        "name": "Voda Filtr Množství"
-      },
-      "descale_status": {
-        "name": "Stav odvápnění"
-      },
-      "water_hardness": {
-        "name": "Voda Tvrdost"
-      },
-      "software_version": {
-        "name": "Verze softwaru"
-      },
-      "last_connected": {
-        "name": "Poslední připojení"
-      },
+      "total_beverages": { "name": "Počet nápojů" },
+      "total_espresso": { "name": "Počet espress" },
+      "total_milk_drinks": { "name": "Počet mléčných nápojů" },
+      "total_water": { "name": "Počet výdejů vody" },
+      "total_espresso_alt": { "name": "Alternativní počet espress" },
+      "total_coffee": { "name": "Počet káv" },
+      "total_long_coffee": { "name": "Počet nápojů Long Coffee" },
+      "total_doppio": { "name": "Počet nápojů Doppio+" },
+      "total_americano": { "name": "Počet nápojů Americano" },
+      "total_cappuccino": { "name": "Počet nápojů Cappuccino" },
+      "total_latte_macchiato": { "name": "Počet nápojů Latte Macchiato" },
+      "total_caffelatte": { "name": "Počet nápojů Caffe Latte" },
+      "total_flat_white": { "name": "Počet nápojů Flat White" },
+      "total_espresso_macchiato": { "name": "Počet nápojů Espresso Macchiato" },
+      "total_hot_milk": { "name": "Počet výdejů horkého mléka" },
+      "total_cappuccino_doppio": { "name": "Počet nápojů Cappuccino Doppio+" },
+      "total_cappuccino_reverse": { "name": "Počet nápojů Cappuccino Reverse" },
+      "total_hot_water": { "name": "Počet výdejů horké vody" },
+      "total_tea": { "name": "Počet čajů" },
+      "total_coffee_pot": { "name": "Počet konvic kávy" },
+      "total_brew_over_ice": { "name": "Počet nápojů Brew Over Ice" },
+      "total_mug_hot": { "name": "Počet horkých nápojů do hrnku" },
+      "total_mug_cold": { "name": "Počet studených nápojů do hrnku" },
+      "total_iced_bev": { "name": "Počet ledových nápojů" },
+      "total_mug_bev": { "name": "Počet nápojů do hrnku" },
+      "total_mug_iced_bev": { "name": "Počet ledových nápojů do hrnku" },
+      "total_cold_brew_bev": { "name": "Počet nápojů Cold Brew" },
+      "grounds_counter": { "name": "Počet porcí sedliny" },
+      "total_descales": { "name": "Počet odvápnění" },
+      "water_total_quantity": { "name": "Spotřeba vody celkem" },
+      "total_filters_used": { "name": "Počet použitých filtrů" },
+      "water_filter_quantity": { "name": "Voda proteklá filtrem" },
+      "descale_status": { "name": "Stav odvápnění" },
+      "water_hardness": { "name": "Tvrdost vody" },
+      "software_version": { "name": "Verze softwaru" },
+      "last_connected": { "name": "Poslední připojení" },
       "connection_status": {
-        "name": "Stav připojení"
+        "name": "Připojení ke cloudu",
+        "state": {
+          "online": "Připojeno",
+          "offline": "Odpojeno",
+          "unknown": "Neznámý stav"
+        }
       },
       "machine_status": {
-        "name": "Stav kávovaru"
+        "name": "Stav kávovaru",
+        "state": {
+          "standby": "Pohotovostní režim",
+          "waking_up": "Zapínání",
+          "going_to_sleep": "Vypínání",
+          "descaling": "Odvápňování",
+          "preparing_steam": "Příprava páry",
+          "recovering": "Obnovování provozu",
+          "ready": "Připraven",
+          "rinsing": "Proplachování",
+          "preparing_milk": "Příprava mléka",
+          "dispensing_hot_water": "Výdej horké vody",
+          "cleaning_milk": "Čištění mléčného systému",
+          "preparing_chocolate": "Příprava čokolády",
+          "preparing_milk_alt": "Příprava mléka",
+          "unknown": "Neznámý stav"
+        }
       },
-      "cloud_session_app_id": {
-        "name": "ID cloudové relace"
-      },
-      "last_captured_command": {
-        "name": "Poslední zachycený příkaz"
-      }
+      "cloud_session_app_id": { "name": "ID cloudové relace" },
+      "last_captured_command": { "name": "Poslední zachycený příkaz" }
     },
     "button": {
-      "start_espresso": {
-        "name": "Espresso"
-      },
-      "start_coffee": {
-        "name": "Coffee"
-      },
-      "start_long_coffee": {
-        "name": "Velká káva"
-      },
-      "start_double_espresso": {
-        "name": "Dvojité Espresso"
-      },
-      "start_doppio": {
-        "name": "Doppio+"
-      },
-      "start_americano": {
-        "name": "Americano"
-      },
-      "start_cappuccino": {
-        "name": "Cappuccino"
-      },
-      "start_latte_macchiato": {
-        "name": "Latte Macchiato"
-      },
-      "start_caffelatte": {
-        "name": "Caffe Latte"
-      },
-      "start_flat_white": {
-        "name": "Flat White"
-      },
-      "start_espresso_macchiato": {
-        "name": "Espresso Macchiato"
-      },
-      "start_hot_milk": {
-        "name": "Horké mléko"
-      },
-      "start_cappuccino_doppio": {
-        "name": "Cappuccino Doppio+"
-      },
-      "start_cappuccino_reverse": {
-        "name": "Cappuccino Reverse"
-      },
-      "start_hot_water": {
-        "name": "Horká voda"
-      },
-      "start_tea": {
-        "name": "Čaj"
-      },
-      "start_coffee_pot": {
-        "name": "Konvice kávy"
-      },
-      "start_cortado": {
-        "name": "Cortado"
-      },
-      "start_long_black": {
-        "name": "Long Black"
-      },
-      "start_mug_to_go": {
-        "name": "S sebou do hrnku"
-      },
-      "start_brew_over_ice": {
-        "name": "Zchlazeno ledem"
-      },
-      "wake": {
-        "name": "Probudit"
-      },
-      "standby": {
-        "name": "Pohotovostní režim"
-      },
-      "stop": {
-        "name": "Zastavit"
-      },
-      "dump_recipes": {
-        "name": "Vypsat data receptů"
-      }
+      "start_espresso": { "name": "Espresso" },
+      "start_coffee": { "name": "Coffee" },
+      "start_long_coffee": { "name": "Long Coffee" },
+      "start_double_espresso": { "name": "Double Espresso" },
+      "start_doppio": { "name": "Doppio+" },
+      "start_americano": { "name": "Americano" },
+      "start_cappuccino": { "name": "Cappuccino" },
+      "start_latte_macchiato": { "name": "Latte Macchiato" },
+      "start_caffelatte": { "name": "Caffe Latte" },
+      "start_flat_white": { "name": "Flat White" },
+      "start_espresso_macchiato": { "name": "Espresso Macchiato" },
+      "start_hot_milk": { "name": "Horké mléko" },
+      "start_cappuccino_doppio": { "name": "Cappuccino Doppio+" },
+      "start_cappuccino_reverse": { "name": "Cappuccino Reverse" },
+      "start_hot_water": { "name": "Horká voda" },
+      "start_tea": { "name": "Čaj" },
+      "start_coffee_pot": { "name": "Konvice kávy" },
+      "start_cortado": { "name": "Cortado" },
+      "start_long_black": { "name": "Long Black" },
+      "start_mug_to_go": { "name": "Mug to Go" },
+      "start_brew_over_ice": { "name": "Brew Over Ice" },
+      "wake": { "name": "Zapnout" },
+      "standby": { "name": "Vypnout" },
+      "stop": { "name": "Zastavit přípravu" },
+      "dump_recipes": { "name": "Vypsat data receptů" }
     },
     "binary_sensor": {
-      "water_tank_empty": {
-        "name": "Prázdná nádržka na vodu"
-      },
-      "waste_container_full": {
-        "name": "Plný odpadní zásobník"
-      },
-      "decalcification_needed": {
-        "name": "Nutné odvápnění"
-      },
-      "filter_change_needed": {
-        "name": "Nutná výměna filtru"
+      "water_tank_empty": { "name": "Prázdná nádržka na vodu" },
+      "waste_container_full": { "name": "Plný zásobník sedliny" },
+      "decalcification_needed": { "name": "Nutné odvápnění" },
+      "filter_change_needed": { "name": "Nutná výměna filtru" }
+    }
+  },
+  "services": {
+    "start_beverage": {
+      "name": "Spustit přípravu nápoje",
+      "description": "Spustí přípravu nápoje na vybraném kávovaru De'Longhi.",
+      "fields": {
+        "beverage": {
+          "name": "Nápoj",
+          "description": "Recept nápoje, který se má připravit."
+        }
+      }
+    },
+    "stop_beverage": {
+      "name": "Zastavit přípravu nápoje",
+      "description": "Zastaví přípravu vybraného nápoje.",
+      "fields": {
+        "beverage": {
+          "name": "Nápoj",
+          "description": "Recept nápoje, jehož příprava se má zastavit."
+        }
+      }
+    },
+    "send_raw_command": {
+      "name": "Odeslat nezpracovaný příkaz",
+      "description": "Odešle kávovaru pokročilý binární příkaz zakódovaný ve formátu base64.",
+      "fields": {
+        "value_base64": {
+          "name": "Příkaz (base64)",
+          "description": "Binární bajty příkazu zakódované ve formátu base64."
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "espresso": "Espresso",
+        "coffee": "Coffee",
+        "long_coffee": "Long Coffee",
+        "double_espresso": "Double Espresso",
+        "doppio": "Doppio+",
+        "americano": "Americano",
+        "cappuccino": "Cappuccino",
+        "latte_macchiato": "Latte Macchiato",
+        "caffelatte": "Caffe Latte",
+        "flat_white": "Flat White",
+        "espresso_macchiato": "Espresso Macchiato",
+        "hot_milk": "Horké mléko",
+        "cappuccino_doppio": "Cappuccino Doppio+",
+        "cappuccino_reverse": "Cappuccino Reverse",
+        "hot_water": "Horká voda",
+        "tea": "Čaj",
+        "coffee_pot": "Konvice kávy",
+        "cortado": "Cortado",
+        "long_black": "Long Black",
+        "mug_to_go": "Mug to Go",
+        "brew_over_ice": "Brew Over Ice"
       }
     }
   }

--- a/custom_components/delonghi_coffeelink/translations/en.json
+++ b/custom_components/delonghi_coffeelink/translations/en.json
@@ -131,10 +131,31 @@
         "name": "Last Connected"
       },
       "connection_status": {
-        "name": "Connection Status"
+        "name": "Cloud Connection",
+        "state": {
+          "online": "Connected",
+          "offline": "Disconnected",
+          "unknown": "Unknown"
+        }
       },
       "machine_status": {
-        "name": "Machine Status"
+        "name": "Machine Status",
+        "state": {
+          "standby": "Standby",
+          "waking_up": "Waking up",
+          "going_to_sleep": "Going to standby",
+          "descaling": "Descaling",
+          "preparing_steam": "Preparing steam",
+          "recovering": "Recovering",
+          "ready": "Ready",
+          "rinsing": "Rinsing",
+          "preparing_milk": "Preparing milk",
+          "dispensing_hot_water": "Dispensing hot water",
+          "cleaning_milk": "Cleaning milk system",
+          "preparing_chocolate": "Preparing chocolate",
+          "preparing_milk_alt": "Preparing milk",
+          "unknown": "Unknown"
+        }
       },
       "cloud_session_app_id": {
         "name": "Cloud Session app_id"
@@ -232,6 +253,65 @@
       },
       "filter_change_needed": {
         "name": "Filter change needed"
+      }
+    }
+  },
+  "services": {
+    "start_beverage": {
+      "name": "Start beverage",
+      "description": "Start preparing a beverage on the selected De'Longhi coffee machine.",
+      "fields": {
+        "beverage": {
+          "name": "Beverage",
+          "description": "Beverage recipe to prepare."
+        }
+      }
+    },
+    "stop_beverage": {
+      "name": "Stop beverage",
+      "description": "Stop preparation of the selected beverage.",
+      "fields": {
+        "beverage": {
+          "name": "Beverage",
+          "description": "Beverage recipe whose preparation should be stopped."
+        }
+      }
+    },
+    "send_raw_command": {
+      "name": "Send raw command",
+      "description": "Send an advanced base64-encoded binary command to the coffee machine.",
+      "fields": {
+        "value_base64": {
+          "name": "Command (base64)",
+          "description": "Base64 representation of the binary command bytes."
+        }
+      }
+    }
+  },
+  "selector": {
+    "beverage": {
+      "options": {
+        "espresso": "Espresso",
+        "coffee": "Coffee",
+        "long_coffee": "Long Coffee",
+        "double_espresso": "Double Espresso",
+        "doppio": "Doppio+",
+        "americano": "Americano",
+        "cappuccino": "Cappuccino",
+        "latte_macchiato": "Latte Macchiato",
+        "caffelatte": "Caffe Latte",
+        "flat_white": "Flat White",
+        "espresso_macchiato": "Espresso Macchiato",
+        "hot_milk": "Hot Milk",
+        "cappuccino_doppio": "Cappuccino Doppio+",
+        "cappuccino_reverse": "Cappuccino Reverse",
+        "hot_water": "Hot Water",
+        "tea": "Tea",
+        "coffee_pot": "Coffee Pot",
+        "cortado": "Cortado",
+        "long_black": "Long Black",
+        "mug_to_go": "Mug to Go",
+        "brew_over_ice": "Brew Over Ice"
       }
     }
   }

--- a/tests/test_counters.py
+++ b/tests/test_counters.py
@@ -28,6 +28,7 @@ def _load(modname: str, filename: str):
 
 counters = _load("counters", "counters.py")
 parse_counter_value = counters.parse_counter_value
+parse_water_volume_liters = counters.parse_water_volume_liters
 counter_breakdown = counters.counter_breakdown
 
 
@@ -66,6 +67,23 @@ def test_parse_counter_value_bool_is_not_int():
     # bool is a subtype of int in Python; ensure we never treat it as a count.
     assert parse_counter_value(True) is None
     assert parse_counter_value(False) is None
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (387213, 387.213),
+        ("387213", 387.213),
+        (0, 0.0),
+        (1, 0.001),
+        (None, None),
+        (True, None),
+        ("not-a-number", None),
+        ('{"part_a": 1000, "part_b": 250}', 1.25),
+    ],
+)
+def test_parse_water_volume_liters(value, expected):
+    assert parse_water_volume_liters(value) == expected
 
 
 # --- counter_breakdown ---------------------------------------------------- #

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -45,6 +45,9 @@ monitor = _load("monitor", "monitor.py")
 parse_monitor_b64 = monitor.parse_monitor_b64
 crc16_aug_ccitt = cb.crc16_aug_ccitt
 MONITOR_REQUEST_ID = monitor.MONITOR_REQUEST_ID
+normalize_connection_status = sys.modules[
+    "delonghi_coffeelink.const"
+].normalize_connection_status
 
 
 def _build_monitor_blob(contents: bytes) -> str:
@@ -143,3 +146,17 @@ def test_malformed_blob_returns_error_not_raise():
     assert "error" in parse_monitor_b64("")
     # Valid base64 but not a MonitorV2 packet.
     assert "error" in parse_monitor_b64(base64.b64encode(b"\x0d\x05\x99\x00").decode())
+
+
+def test_unknown_machine_status_uses_stable_enum_key():
+    contents = bytearray(8)
+    contents[5] = 0xFE
+    result = parse_monitor_b64(_build_monitor_blob(bytes(contents)))
+    assert result["status_name"] == "unknown"
+
+
+def test_connection_status_is_normalized_to_enum_keys():
+    assert normalize_connection_status("Online") == "online"
+    assert normalize_connection_status(" offline ") == "offline"
+    assert normalize_connection_status("unexpected") == "unknown"
+    assert normalize_connection_status(None) == "unknown"

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,99 @@
+"""Regression tests for English and Czech translation completeness."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+COMPONENT_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "delonghi_coffeelink"
+)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def _leaf_keys(value: dict[str, Any], prefix: str = "") -> set[str]:
+    keys: set[str] = set()
+    for key, item in value.items():
+        path = f"{prefix}.{key}" if prefix else key
+        if isinstance(item, dict):
+            keys.update(_leaf_keys(item, path))
+        else:
+            keys.add(path)
+    return keys
+
+
+def test_english_and_czech_match_source_translation_keys():
+    source = _load_json(COMPONENT_DIR / "strings.json")
+    expected = _leaf_keys(source)
+
+    for language in ("en", "cs"):
+        translation = _load_json(COMPONENT_DIR / "translations" / f"{language}.json")
+        assert _leaf_keys(translation) == expected
+
+
+def test_enum_state_keys_are_complete():
+    source = _load_json(COMPONENT_DIR / "strings.json")
+    sensors = source["entity"]["sensor"]
+
+    assert set(sensors["connection_status"]["state"]) == {
+        "online",
+        "offline",
+        "unknown",
+    }
+    assert set(sensors["machine_status"]["state"]) == {
+        "standby",
+        "waking_up",
+        "going_to_sleep",
+        "descaling",
+        "preparing_steam",
+        "recovering",
+        "ready",
+        "rinsing",
+        "preparing_milk",
+        "dispensing_hot_water",
+        "cleaning_milk",
+        "preparing_chocolate",
+        "preparing_milk_alt",
+        "unknown",
+    }
+
+
+def test_services_use_translated_metadata_and_selector_options():
+    services_yaml = (COMPONENT_DIR / "services.yaml").read_text(encoding="utf-8")
+    source = _load_json(COMPONENT_DIR / "strings.json")
+
+    assert set(source["services"]) == {
+        "start_beverage",
+        "stop_beverage",
+        "send_raw_command",
+    }
+    assert "translation_key: beverage" in services_yaml
+    assert set(source["selector"]["beverage"]["options"]) == {
+        "espresso",
+        "coffee",
+        "long_coffee",
+        "double_espresso",
+        "doppio",
+        "americano",
+        "cappuccino",
+        "latte_macchiato",
+        "caffelatte",
+        "flat_white",
+        "espresso_macchiato",
+        "hot_milk",
+        "cappuccino_doppio",
+        "cappuccino_reverse",
+        "hot_water",
+        "tea",
+        "coffee_pot",
+        "cortado",
+        "long_black",
+        "mug_to_go",
+        "brew_over_ice",
+    }


### PR DESCRIPTION
## Summary
- complete the Czech config-flow, entity, action, selector and enum-state translations
- keep the English and Czech translation trees structurally identical
- translate service actions through Home Assistant translation keys instead of hard-coded YAML labels
- convert only water-volume counters `d553` and `d555` from raw millilitres to litres with three-decimal precision
- apply `WATER` metadata and the correct `TOTAL` / `TOTAL_INCREASING` state classes; leave unrelated counter `d550` unscaled

## Why
The water properties are cumulative millilitre counters, while Home Assistant expects a declared volume unit. Converting at the entity boundary preserves stable unique IDs and produces correct long-term statistics. Translation-parity tests prevent Czech strings from silently falling behind English.

## Validation
- 101 pytest tests pass
- Ruff checks pass
- JSON catalogs parse successfully
- regression coverage includes translation parity, enum keys, malformed counters and exact mL-to-L conversion

Fixes #19