### PR TITLE
Add pytest coverage, Ruff and pinned GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,19 +8,69 @@ on:
   schedule:
     - cron: "37 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS validation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: hacs/action@main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa # main, 2026-08-14
         with:
           category: integration
 
   hassfest:
     name: Hassfest (manifest.json)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: home-assistant/actions/hassfest@master
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: home-assistant/actions/hassfest@a7c616ce81ccda50150bf1595786c71b1883fabb # master, 2026-08-14
+
+  tests:
+    name: Tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - name: Install test dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements-test.txt
+      - name: Run tests with coverage
+        run: >-
+          pytest
+          --cov=custom_components/delonghi_coffeelink
+          --cov-report=term-missing
+          --cov-fail-under=25
+      - name: Add coverage to job summary
+        if: always()
+        run: coverage report --format=markdown >> "$GITHUB_STEP_SUMMARY"
+
+  lint:
+    name: Ruff lint and format
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: requirements-test.txt
+      - name: Install lint dependencies
+        run: python -m pip install --disable-pip-version-check -r requirements-test.txt
+      - name: Check lint and import order
+        run: ruff check .
+      - name: Check formatter migration baseline
+        run: ruff format --check tests/test_ci_regressions.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F", "I"]
+
+[tool.ruff.lint.per-file-ignores]
+"custom_components/delonghi_coffeelink/ayla_client.py" = ["I001"]
+"custom_components/delonghi_coffeelink/config_flow.py" = ["F401"]
+"custom_components/delonghi_coffeelink/coordinator.py" = ["I001"]
+"custom_components/delonghi_coffeelink/sensor.py" = ["F401", "I001"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,4 @@
+aiohttp>=3.12,<4
+pytest>=8.4,<9
+pytest-cov>=6.2,<8
+ruff>=0.12,<1

--- a/tests/test_ci_regressions.py
+++ b/tests/test_ci_regressions.py
@@ -1,0 +1,46 @@
+"""Focused CI regressions captured from field reports."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+PKG_DIR = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "delonghi_coffeelink"
+)
+PKG_NAME = "delonghi_ci_regressions"
+
+package = types.ModuleType(PKG_NAME)
+package.__path__ = [str(PKG_DIR)]
+sys.modules[PKG_NAME] = package
+
+
+def _load(name: str):
+    full_name = f"{PKG_NAME}.{name}"
+    spec = importlib.util.spec_from_file_location(full_name, PKG_DIR / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_load("const")
+command_builder = _load("command_builder")
+
+
+def test_eletta_field_frame_signature_and_app_id():
+    """Keep the exact valid frame, signature and decimal app id from issue #15."""
+    captured = "DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh"
+    decoded = command_builder.decode_command(captured)
+
+    assert decoded["type"] == "beverage"
+    assert decoded["beverage_id"] == "0x02"
+    assert decoded["recipe"] == "01 00 6e 02 03 27 01 06"
+    assert decoded["crc_valid"] is True
+
+    signature = command_builder.device_signature_from_frame(captured)
+    assert signature == bytes.fromhex("00 c5 86 21")
+    assert int.from_bytes(signature, "big") == 12_944_929


### PR DESCRIPTION
## Summary
- run the test suite on Python 3.12 and 3.13
- publish branch-aware coverage with a realistic initial 25% gate (current result: 27.48%)
- add Ruff lint and import-order checks plus a formatter baseline for new regression code
- pin checkout, setup-python, HACS and Hassfest Actions to immutable commit SHAs
- restrict workflow permissions to read-only and add weekly Dependabot updates for Actions and Python tooling
- add a regression for the real Eletta frame `DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh`, signature `00 c5 86 21` and app ID `12944929`

## Reviewability
This intentionally avoids a repository-wide mechanical reformat. The small set of pre-existing lint exceptions is documented per file; changed reliability/localization code is still linted, and formatter coverage can be expanded incrementally without obscuring functional reviews.

## Validation
- 89 tests pass
- total branch coverage: 27.48%
- Ruff lint/import checks pass
- formatter check passes for the added regression module

Fixes #21