### PR TITLE
Make commands truthful, targeted and reauth-safe

### DIFF
--- a/custom_components/delonghi_coffeelink/__init__.py
+++ b/custom_components/delonghi_coffeelink/__init__.py
@@ -1,15 +1,25 @@
-"""DeLonghi Coffee Link integration (PrimaDonna Soul et autres modeles Ayla-based)."""
+"""DeLonghi Coffee Link integration."""
+
 from __future__ import annotations
 
+import asyncio
 import logging
+from dataclasses import dataclass
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import ATTR_DEVICE_ID, Platform
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    HomeAssistantError,
+)
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.typing import ConfigType
 
 from .ayla_client import AuthError, CloudError, DelonghiAylaClient
 from .const import (
@@ -28,15 +38,110 @@ from .coordinator import DelonghiCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
+BEVERAGE_KEYS = [beverage[1] for beverage in BEVERAGES]
+BEVERAGE_IDS = {beverage[1]: beverage[0] for beverage in BEVERAGES}
 
-BEVERAGE_KEYS = [b[1] for b in BEVERAGES]
+DEVICE_TARGET = {vol.Required(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string])}
+SERVICE_START_SCHEMA = vol.Schema(
+    {**DEVICE_TARGET, vol.Required("beverage"): vol.In(BEVERAGE_KEYS)}
+)
+SERVICE_STOP_SCHEMA = vol.Schema(
+    {**DEVICE_TARGET, vol.Optional("beverage"): vol.In(BEVERAGE_KEYS)}
+)
+SERVICE_RAW_SCHEMA = vol.Schema(
+    {**DEVICE_TARGET, vol.Required("value_base64"): cv.string}
+)
 
-SERVICE_START_SCHEMA = vol.Schema({vol.Required("beverage"): vol.In(BEVERAGE_KEYS)})
-SERVICE_STOP_SCHEMA = vol.Schema({vol.Required("beverage"): vol.In(BEVERAGE_KEYS)})
-SERVICE_RAW_SCHEMA = vol.Schema({vol.Required("value_base64"): cv.string})
+
+@dataclass(slots=True)
+class DelonghiRuntimeData:
+    """Runtime objects owned by one config entry."""
+
+    client: DelonghiAylaClient
+    coordinators: list[DelonghiCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+def _coordinators(hass: HomeAssistant) -> list[DelonghiCoordinator]:
+    """Return coordinators from loaded config entries only."""
+    result: list[DelonghiCoordinator] = []
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        if entry.state is not ConfigEntryState.LOADED:
+            continue
+        runtime = getattr(entry, "runtime_data", None)
+        if isinstance(runtime, DelonghiRuntimeData):
+            result.extend(runtime.coordinators)
+    return result
+
+
+def _target_coordinator(hass: HomeAssistant, call: ServiceCall) -> DelonghiCoordinator:
+    """Resolve one explicit Home Assistant device target."""
+    device_ids = call.data[ATTR_DEVICE_ID]
+    if len(device_ids) != 1:
+        raise HomeAssistantError("Select exactly one DeLonghi coffee maker")
+
+    device = dr.async_get(hass).async_get(device_ids[0])
+    if device is None:
+        raise HomeAssistantError("The selected Home Assistant device no longer exists")
+
+    dsns = {
+        identifier[1]
+        for identifier in device.identifiers
+        if identifier[0] == DOMAIN
+    }
+    matches = [coord for coord in _coordinators(hass) if coord.device.dsn in dsns]
+    if len(matches) != 1:
+        raise HomeAssistantError(
+            "The selected target does not resolve to exactly one loaded DeLonghi coffee maker"
+        )
+    return matches[0]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Register integration actions once for the lifetime of Home Assistant."""
+
+    async def _start_beverage(call: ServiceCall) -> None:
+        coordinator = _target_coordinator(hass, call)
+        await coordinator.async_send_beverage(
+            BEVERAGE_IDS[call.data["beverage"]], ACTION_START
+        )
+
+    async def _stop_beverage(call: ServiceCall) -> None:
+        coordinator = _target_coordinator(hass, call)
+        if beverage := call.data.get("beverage"):
+            await coordinator.async_send_beverage(BEVERAGE_IDS[beverage], ACTION_STOP)
+        else:
+            await coordinator.async_stop_active_beverage()
+
+    async def _send_raw(call: ServiceCall) -> None:
+        coordinator = _target_coordinator(hass, call)
+        await coordinator.async_send_raw(call.data["value_base64"])
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_START_BEVERAGE,
+        _start_beverage,
+        schema=SERVICE_START_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_STOP_BEVERAGE,
+        _stop_beverage,
+        schema=SERVICE_STOP_SCHEMA,
+    )
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_SEND_RAW_COMMAND,
+        _send_raw,
+        schema=SERVICE_RAW_SCHEMA,
+    )
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry[DelonghiRuntimeData]
+) -> bool:
+    """Set up one Coffee Link account and refresh every discovered machine."""
     session = async_get_clientsession(hass)
     client = DelonghiAylaClient(session, entry.data[CONF_EMAIL], entry.data[CONF_PASSWORD])
 
@@ -44,88 +149,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await client.async_authenticate()
         devices = await client.async_get_devices()
     except AuthError as err:
-        raise ConfigEntryNotReady(f"DeLonghi auth failed: {err}") from err
+        raise ConfigEntryAuthFailed("Coffee Link credentials were rejected") from err
     except CloudError as err:
-        raise ConfigEntryNotReady(f"DeLonghi cloud error: {err}") from err
+        raise ConfigEntryNotReady(f"DeLonghi cloud is temporarily unavailable: {err}") from err
 
     if not devices:
         raise ConfigEntryNotReady("No DeLonghi devices found on this account")
 
-    for device in devices:
-        _LOGGER.debug(
-            "Discovered DeLonghi device: dsn=%s oem_model=%s model=%s sw_version=%s "
-            "connection_status=%s lan_ip=%s",
-            device.dsn,
-            device.oem_model,
-            device.model,
-            device.sw_version,
-            device.connection_status,
-            device.lan_ip,
-        )
-
-    # One coordinator per device
     coordinators: list[DelonghiCoordinator] = []
-    for device in devices:
-        coord = DelonghiCoordinator(hass, client, device)
-        # Restore any Eletta frames learned in previous runs before the first
-        # refresh, so buttons can replay immediately after a restart.
-        await coord.async_load_learned()
-        await coord.async_config_entry_first_refresh()
-        if coord.data:
-            prop_names = sorted(coord.data.keys())
-            _LOGGER.debug(
-                "Ayla properties for dsn=%s (%d total): %s",
-                device.dsn,
-                len(prop_names),
-                ", ".join(prop_names),
-            )
-        coordinators.append(coord)
+    try:
+        for device in devices:
+            coordinator = DelonghiCoordinator(hass, client, device)
+            await coordinator.async_load_learned()
+            await coordinator.async_config_entry_first_refresh()
+            coordinators.append(coordinator)
+    except Exception:
+        await asyncio.gather(
+            *(coordinator.async_shutdown() for coordinator in coordinators),
+            return_exceptions=True,
+        )
+        raise
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinators
-
+    entry.runtime_data = DelonghiRuntimeData(client, coordinators)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    _register_services(hass, coordinators)
-
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: ConfigEntry[DelonghiRuntimeData]
+) -> bool:
+    """Unload platforms and stop coordinator work for one account."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        for coord in hass.data.get(DOMAIN, {}).get(entry.entry_id, []):
-            if coord.profile.uses_cloud_session:
-                await coord.async_shutdown()
-        hass.data[DOMAIN].pop(entry.entry_id, None)
+        await asyncio.gather(
+            *(coordinator.async_shutdown() for coordinator in entry.runtime_data.coordinators),
+            return_exceptions=True,
+        )
     return unload_ok
-
-
-def _register_services(hass: HomeAssistant, coordinators: list[DelonghiCoordinator]) -> None:
-    """Register integration-level services (apply to all devices for now)."""
-    # Build lookup for beverage_id by key
-    bev_by_key = {b[1]: b[0] for b in BEVERAGES}
-
-    async def _start_beverage(call: ServiceCall) -> None:
-        bev_id = bev_by_key[call.data["beverage"]]
-        for coord in coordinators:
-            await coord.async_send_beverage(bev_id, ACTION_START)
-
-    async def _stop_beverage(call: ServiceCall) -> None:
-        bev_id = bev_by_key[call.data["beverage"]]
-        for coord in coordinators:
-            await coord.async_send_beverage(bev_id, ACTION_STOP)
-
-    async def _send_raw(call: ServiceCall) -> None:
-        value = call.data["value_base64"]
-        for coord in coordinators:
-            await coord.async_send_raw(value)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_START_BEVERAGE, _start_beverage, schema=SERVICE_START_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_STOP_BEVERAGE, _stop_beverage, schema=SERVICE_STOP_SCHEMA
-    )
-    hass.services.async_register(
-        DOMAIN, SERVICE_SEND_RAW_COMMAND, _send_raw, schema=SERVICE_RAW_SCHEMA
-    )

--- a/custom_components/delonghi_coffeelink/ayla_client.py
+++ b/custom_components/delonghi_coffeelink/ayla_client.py
@@ -21,7 +21,6 @@ import aiohttp
 from .const import (
     APP_ID,
     APP_SECRET,
-    APP_ID_PROPERTY,
     AYLA_EU_ADS_URL,
     AYLA_EU_USER_URL,
     CLOUD_HTTP_RETRY_BACKOFF,
@@ -248,7 +247,7 @@ class DelonghiAylaClient:
                 raise AuthError(f"Ayla SSO failed (HTTP {resp.status}): {text[:300]}")
             body = await resp.json()
         if "access_token" not in body:
-            raise AuthError(f"Ayla SSO: no access_token in response: {body}")
+            raise AuthError("Ayla SSO response did not contain an access token")
         self._access_token = body["access_token"]
         self._refresh_token = body.get("refresh_token")
         self._expires_at = time.time() + body.get("expires_in", 3600)
@@ -337,10 +336,10 @@ class DelonghiAylaClient:
             raise CloudError(f"get_property {property_name}: unexpected response {data!r}")
         raw = prop.get("value")
         _LOGGER.debug(
-            "Property %s dsn=%s value=%s",
+            "Property %s dsn=%s value_hint=%s",
             property_name,
             dsn,
-            raw if property_name == APP_ID_PROPERTY else self._value_hint(raw),
+            self._value_hint(raw),
         )
         return prop
 
@@ -357,11 +356,9 @@ class DelonghiAylaClient:
             + integration_app_id_to_bytes(integration_app_id)
         ).decode("utf-8")
         _LOGGER.info(
-            "POST cloud session connect dsn=%s property=%s app_id=%d (0x%08x) payload_len=%d",
+            "POST cloud session connect dsn=%s property=%s payload_len=%d",
             dsn,
             connected_property,
-            integration_app_id,
-            integration_app_id & 0xFFFFFFFF,
             len(payload),
         )
         url = (

--- a/custom_components/delonghi_coffeelink/binary_sensor.py
+++ b/custom_components/delonghi_coffeelink/binary_sensor.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry.runtime_data.coordinators
     entities: list[BinarySensorEntity] = []
     for coord in coordinators:
         # Maintenance bitfields are ECAM-only; never create these on Soul.

--- a/custom_components/delonghi_coffeelink/button.py
+++ b/custom_components/delonghi_coffeelink/button.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ACTION_START, ACTION_STOP, BEVERAGES, DOMAIN, MANUFACTURER
+from .const import ACTION_START, BEVERAGES, DOMAIN, MANUFACTURER
 from .coordinator import DelonghiCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry.runtime_data.coordinators
     entities: list[ButtonEntity] = []
     for coord in coordinators:
         entities.append(DelonghiWakeButton(coord))
@@ -71,6 +71,14 @@ class DelonghiStartBeverageButton(_Base):
         _LOGGER.info("Start beverage 0x%02x (%s)", self._bev_id, self.name)
         await self.coordinator.async_send_beverage(self._bev_id, ACTION_START)
 
+    @property
+    def available(self) -> bool:
+        """Do not offer a known-incompatible synthesized command."""
+        return super().available and (
+            not self.coordinator.profile.learns_from_app
+            or self._bev_id in self.coordinator.learned_start_frames
+        )
+
 
 class DelonghiWakeButton(_Base):
     """Wake the machine from standby (captured cmd family 0x84 0x0f)."""
@@ -106,7 +114,7 @@ class DelonghiStandbyButton(_Base):
 
 
 class DelonghiStopButton(_Base):
-    """Press to STOP currently-running beverage (uses hot_water id + stop action as generic)."""
+    """Stop the beverage tracked by the coordinator."""
 
     def __init__(self, coord: DelonghiCoordinator) -> None:
         super().__init__(coord)
@@ -115,11 +123,16 @@ class DelonghiStopButton(_Base):
         self._attr_icon = "mdi:stop"
 
     async def async_press(self) -> None:
-        # NOTE: the exact beverage_id used to stop may matter; using 0x10 (hot water)
-        # since that's the captured example. If machine needs the running beverage id,
-        # a future version can track current bev and stop it appropriately.
-        _LOGGER.info("Generic stop command")
-        await self.coordinator.async_send_beverage(0x10, ACTION_STOP)
+        await self.coordinator.async_stop_active_beverage()
+
+    @property
+    def available(self) -> bool:
+        """Stop is safe only while the active beverage is known."""
+        beverage_id = self.coordinator.active_beverage_id
+        return super().available and beverage_id is not None and (
+            not self.coordinator.profile.learns_from_app
+            or beverage_id in self.coordinator.learned_stop_frames
+        )
 
 
 class DelonghiDumpRecipesButton(_Base):

--- a/custom_components/delonghi_coffeelink/config_flow.py
+++ b/custom_components/delonghi_coffeelink/config_flow.py
@@ -1,12 +1,13 @@
 """Config flow for the DeLonghi Coffee Link integration."""
+
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
@@ -21,49 +22,87 @@ STEP_USER_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
     }
 )
+STEP_REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 
 class DelonghiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle the config flow."""
+    """Handle initial setup and credential reauthentication."""
 
     VERSION = 1
+
+    async def _async_validate_account(self, email: str, password: str) -> tuple[str | None, Any]:
+        """Validate credentials and return an error key plus discovered devices."""
+        client = DelonghiAylaClient(
+            async_get_clientsession(self.hass), email.strip(), password
+        )
+        try:
+            await client.async_authenticate()
+            devices = await client.async_get_devices()
+        except AuthError:
+            return "invalid_auth", None
+        except CloudError:
+            return "cannot_connect", None
+        except Exception:
+            _LOGGER.exception("Unexpected Coffee Link validation error")
+            return "unknown", None
+        if not devices:
+            return "no_devices", None
+        return None, devices
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
+        """Create a config entry after testing the account."""
         errors: dict[str, str] = {}
         if user_input is not None:
             email = user_input[CONF_EMAIL].strip()
-            password = user_input[CONF_PASSWORD]
-            session = async_get_clientsession(self.hass)
-            client = DelonghiAylaClient(session, email, password)
-            try:
-                await client.async_authenticate()
-                devices = await client.async_get_devices()
-            except AuthError as err:
-                _LOGGER.error("Auth failed: %s", err)
-                errors["base"] = "invalid_auth"
-            except CloudError as err:
-                _LOGGER.error("Cloud error: %s", err)
-                errors["base"] = "cannot_connect"
-            except Exception:
-                _LOGGER.exception("Unexpected error during auth")
-                errors["base"] = "unknown"
+            error, devices = await self._async_validate_account(
+                email, user_input[CONF_PASSWORD]
+            )
+            if error:
+                errors["base"] = error
             else:
-                if not devices:
-                    errors["base"] = "no_devices"
-                else:
-                    # Use the user's email as unique_id to prevent duplicate entries
-                    await self.async_set_unique_id(email.lower())
-                    self._abort_if_unique_id_configured()
-                    return self.async_create_entry(
-                        title=f"DeLonghi ({devices[0].name})",
-                        data={CONF_EMAIL: email, CONF_PASSWORD: password},
-                    )
+                await self.async_set_unique_id(email.casefold())
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=f"DeLonghi ({devices[0].name})",
+                    data={
+                        CONF_EMAIL: email,
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
 
         return self.async_show_form(
             step_id="user",
             data_schema=STEP_USER_SCHEMA,
             errors=errors,
-            description_placeholders={"email": "Coffee Link account email"},
+        )
+
+    async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
+        """Start reauthentication for an existing entry."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Validate and save a replacement password without duplicating the entry."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            error, _devices = await self._async_validate_account(
+                reauth_entry.data[CONF_EMAIL], user_input[CONF_PASSWORD]
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_PASSWORD: user_input[CONF_PASSWORD]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=STEP_REAUTH_SCHEMA,
+            errors=errors,
+            description_placeholders={"email": reauth_entry.data[CONF_EMAIL]},
         )

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -27,16 +27,17 @@ COMMAND_PROPERTY_CANDIDATES = ["data_request", "app_data_request"]
 RESPONSE_PROPERTY_CANDIDATES = ["data_response", "app_data_response"]
 CONNECTED_PROPERTY_CANDIDATES = ["device_connected", "app_device_connected"]
 
-# Stable HA client id for app_device_connected (DlghIoT uses 0xC0FFEE11).
-# Used ONLY for session registration and property app_id checks.
-# NOT the 4-byte device signature appended to learned command frames.
+# Fallback cloud client id until an ECAM frame has supplied the machine-specific
+# 4-byte signature. Learned signatures replace this value for session registration.
 INTEGRATION_CLOUD_APP_ID = 0xC0FFEE11
 
 APP_ID_PROPERTY = "app_id"  # machine property: current session holder
 CONNECT_REFRESH_INTERVAL = 240  # refresh before 4*60s (device timeout ~300s)
-CONNECT_SETTLE_DELAY = 4  # sleep after POST connect (background tasks only)
+CONNECT_SETTLE_DELAY = 4  # sleep after POST connect before confirmation
 CONNECT_CONFIRM_TIMEOUT = 300  # poll app_id after POST (Eletta; can exceed 180s on bad cloud days)
 CONNECT_CONFIRM_POLL_INTERVAL = 1  # seconds between app_id polls during confirm
+COMMAND_CONFIRM_TIMEOUT = 8  # wait for a response marker or monitor transition
+COMMAND_CONFIRM_POLL_INTERVAL = 1
 
 # Ayla HTTP resilience (502/503/504 gateway timeouts seen on ads-eu.aylanetworks.com).
 CLOUD_HTTP_RETRY_COUNT = 2

--- a/custom_components/delonghi_coffeelink/coordinator.py
+++ b/custom_components/delonghi_coffeelink/coordinator.py
@@ -10,10 +10,17 @@ from datetime import timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .ayla_client import AylaDevice, CloudError, DelonghiAylaClient, normalize_signed_app_id
+from .ayla_client import (
+    AuthError,
+    AylaDevice,
+    CloudError,
+    DelonghiAylaClient,
+    normalize_signed_app_id,
+)
 from .command_builder import (
     builder_structural_b64,
     build_session_refresh_encoded,
@@ -27,13 +34,14 @@ from .command_builder import (
     recipe_dump_lines,
     replay_with_timestamp,
     serialize_learned_frames,
-    summarize_decoded,
     validate_replayed_wake_frame,
 )
 from .const import (
     ACTION_STOP,
     APP_ID_PROPERTY,
     COMMAND_PROPERTY_CANDIDATES,
+    COMMAND_CONFIRM_POLL_INTERVAL,
+    COMMAND_CONFIRM_TIMEOUT,
     CONNECT_CONFIRM_POLL_INTERVAL,
     CONNECT_CONFIRM_TIMEOUT,
     CONNECT_REFRESH_INTERVAL,
@@ -85,11 +93,11 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._last_connect_at: float = 0
         self._session_confirmed = False
         self._session_connect_lock = asyncio.Lock()
-        self._session_cold_task: asyncio.Task[None] | None = None
+        self._command_lock = asyncio.Lock()
+        self.active_beverage_id: int | None = None
+        self.last_command_result = "idle"
         if self.profile.uses_cloud_session:
             self._last_seen_app_id: int | None = None
-        else:
-            self._session_refresh_task: asyncio.Task[None] | None = None
         # --- Command sniffer state ---------------------------------------
         # Values WE wrote, so a command echoed back by the cloud is not
         # mis-attributed to the official app. Bounded; only recent writes matter.
@@ -123,9 +131,6 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     async def async_shutdown(self) -> None:
         """Cancel in-flight session work and reset session state on unload."""
-        if self._session_cold_task and not self._session_cold_task.done():
-            self._session_cold_task.cancel()
-        self._session_cold_task = None
         self._last_connect_at = 0
         if self._integration_app_id != self._default_app_id:
             self._integration_app_id = self._default_app_id
@@ -162,6 +167,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.device = d
                     break
             return props
+        except AuthError as err:
+            raise ConfigEntryAuthFailed("Coffee Link credentials are no longer valid") from err
         except CloudError as err:
             raise UpdateFailed(f"Ayla cloud error: {err}") from err
         except Exception as err:
@@ -275,10 +282,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         poll_count = 0
         cloud_errors = 0
         _LOGGER.debug(
-            "Waiting for cloud session confirm on dsn=%s (timeout=%ds, want app_id=%d)",
-            self.device.dsn,
+            "Waiting for cloud session confirmation (timeout=%ds)",
             CONNECT_CONFIRM_TIMEOUT,
-            self._integration_app_id,
         )
         while time.time() - started < CONNECT_CONFIRM_TIMEOUT:
             poll_count += 1
@@ -289,11 +294,7 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 elapsed = time.time() - started
                 self._session_confirmed = True
                 _LOGGER.info(
-                    "Cloud session confirmed app_id=%d (0x%08x) on dsn=%s after %.1fs "
-                    "(polls=%d, cloud_errors=%d)",
-                    app_id,
-                    app_id & 0xFFFFFFFF,
-                    self.device.dsn,
+                    "Cloud session confirmed after %.1fs (polls=%d, cloud_errors=%d)",
                     elapsed,
                     poll_count,
                     cloud_errors,
@@ -303,25 +304,20 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             now = time.time()
             if now - last_progress >= 15:
                 _LOGGER.debug(
-                    "Still waiting for cloud session confirm on dsn=%s (%.0fs/%ds, "
-                    "app_id=%s, want=%d, polls=%d, cloud_errors=%d)",
-                    self.device.dsn,
+                    "Still waiting for cloud session confirmation (%.0fs/%ds, "
+                    "polls=%d, cloud_errors=%d)",
                     now - started,
                     CONNECT_CONFIRM_TIMEOUT,
-                    app_id if fetch_ok else "fetch_failed",
-                    self._integration_app_id,
                     poll_count,
                     cloud_errors,
                 )
                 last_progress = now
-        last_app_id, last_ok = await self._fetch_app_id_live()
+        _last_app_id, last_ok = await self._fetch_app_id_live()
         _LOGGER.warning(
-            "Connect POST sent but app_id not confirmed after %ds on dsn=%s "
-            "(last app_id=%s, want=%d, polls=%d, cloud_errors=%d)",
+            "Connect POST sent but the session was not confirmed after %ds "
+            "(last fetch ok=%s, polls=%d, cloud_errors=%d)",
             CONNECT_CONFIRM_TIMEOUT,
-            self.device.dsn,
-            last_app_id if last_ok else "fetch_failed",
-            self._integration_app_id,
+            last_ok,
             poll_count,
             cloud_errors,
         )
@@ -339,13 +335,9 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     holder = "ha"
                 else:
                     holder = "foreign"
-                unsigned = (app_id or 0) & 0xFFFFFFFF
                 _LOGGER.debug(
-                    "Cloud session app_id=%s (0x%08x) holder=%s dsn=%s",
-                    app_id if app_id is not None else "None",
-                    unsigned,
+                    "Cloud session holder changed to %s",
                     holder,
-                    self.device.dsn,
                 )
                 self._last_seen_app_id = app_id
             self._session_confirmed = (
@@ -364,6 +356,16 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception:  # noqa: BLE001 - diagnostic must not break polling
             _LOGGER.debug("Session parse failed (non-fatal)", exc_info=True)
 
+    def cloud_session_holder(self, app_id: int | None) -> str:
+        """Return a privacy-safe session-holder label."""
+        if app_id is None:
+            return "unknown"
+        if app_id == 0:
+            return "free"
+        if app_id == self._integration_app_id:
+            return "ha"
+        return "foreign"
+
     def _revert_foreign_app_id_if_session_clear(self, app_id: int | None) -> None:
         """Before a cold POST, use our own cloud id when no session is held."""
         if app_id in (None, 0) and self._integration_app_id != self._default_app_id:
@@ -374,34 +376,59 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._integration_app_id = self._default_app_id
             self._last_connect_at = 0
 
-    async def _send_property_command(self, value: str, label: str) -> None:
+    def _command_confirmation_snapshot(self) -> tuple[Any, dict[str, Any]]:
+        """Return privacy-safe state used to detect a machine acknowledgement."""
+        return self._last_resp_marker, dict(self.monitor)
+
+    async def _wait_for_command_confirmation(
+        self, before: tuple[Any, dict[str, Any]]
+    ) -> bool | None:
+        """Return True/False for supported confirmation, or None if unavailable."""
+        if self.response_property is None and not self.monitor:
+            return None
+
+        response_marker, monitor = before
+        deadline = time.monotonic() + COMMAND_CONFIRM_TIMEOUT
+        while time.monotonic() < deadline:
+            await self.async_request_refresh()
+            if self.response_property and self._last_resp_marker != response_marker:
+                return True
+            if self.monitor and self.monitor != monitor:
+                return True
+            await asyncio.sleep(COMMAND_CONFIRM_POLL_INTERVAL)
+        return False
+
+    async def _send_property_command(
+        self, value: str, label: str, *, confirm: bool = True
+    ) -> None:
         prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
+        before = self._command_confirmation_snapshot()
         self._record_sent(value)
         _LOGGER.info("Sending %s via %s (len=%d)", label, prop, len(value))
-        _LOGGER.debug("Sending %s via %s: %s", label, prop, value)
         await self.client.async_set_property_value(self.device.dsn, prop, value)
-        await self.async_request_refresh()
+        self.last_command_result = "sent"
+        if not confirm:
+            return
+        confirmed = await self._wait_for_command_confirmation(before)
+        if confirmed is True:
+            self.last_command_result = "acknowledged"
+        elif confirmed is False:
+            self.last_command_result = "timed_out"
+            raise HomeAssistantError(
+                "The command was sent, but the coffee maker did not acknowledge it in time"
+            )
 
     async def _maybe_send_session_refresh(self) -> None:
         """DlghIoT refresh(): nudge deep standby before wake when monitor=0."""
         if self.monitor.get("status") != 0:
             return
         value = build_session_refresh_encoded(self._integration_app_id)
-        _LOGGER.info(
-            "Machine in standby; sending session refresh before wake (tail app_id=%d)",
-            self._integration_app_id,
-        )
-        await self._send_property_command(value, "SESSION REFRESH")
+        _LOGGER.info("Machine in standby; sending a session refresh before wake")
+        await self._send_property_command(value, "SESSION REFRESH", confirm=False)
 
     def _wake_command_value(self) -> str:
         """Build wake frame for ECAM models (session tail). Soul uses main inline path."""
-        value = build_wake_with_session_tail_encoded(self._integration_app_id)
-        _LOGGER.debug(
-            "Wake frame session tail app_id=%d (0x%08x)",
-            self._integration_app_id,
-            self._integration_app_id & 0xFFFFFFFF,
-        )
-        return value
+        return build_wake_with_session_tail_encoded(self._integration_app_id)
 
     def _standby_command_value(self) -> str:
         """Build standby frame for ECAM models (session tail). Soul uses main inline path."""
@@ -428,49 +455,6 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._integration_app_id,
         )
 
-    async def _cold_connect_then(
-        self, send_fn: Callable[[], Awaitable[None]]
-    ) -> None:
-        try:
-            # The lock serializes concurrent cold connects: the first task does
-            # the POST + settle, the ones queued behind it find the session
-            # fresh and go straight to their send. No command is ever dropped.
-            async with self._session_connect_lock:
-                if not self._session_is_fresh(None):
-                    app_id = await self._read_app_id(live=True)
-                    self._revert_foreign_app_id_if_session_clear(app_id)
-                    _LOGGER.debug(
-                        "Cold cloud session connect starting dsn=%s (app_id before=%s)",
-                        self.device.dsn,
-                        app_id,
-                    )
-                    await self._post_cloud_session()
-                    await asyncio.sleep(CONNECT_SETTLE_DELAY)
-                    if not await self._wait_for_session_confirmed():
-                        return
-                    self._last_connect_at = time.time()
-                elif not self._session_confirmed:
-                    app_id, fetch_ok = await self._fetch_app_id_live()
-                    if not fetch_ok or app_id != self._integration_app_id:
-                        _LOGGER.warning(
-                            "Warm session cache but app_id=%s (fetch_ok=%s) != %d on dsn=%s; "
-                            "skipping command",
-                            app_id,
-                            fetch_ok,
-                            self._integration_app_id,
-                            self.device.dsn,
-                        )
-                        return
-            await send_fn()
-        except Exception:  # noqa: BLE001 - strict: do not send after connect failure
-            _LOGGER.warning(
-                "Cold cloud session connect failed for dsn=%s; command not sent",
-                self.device.dsn,
-                exc_info=True,
-            )
-        finally:
-            self._session_cold_task = None
-
     async def _with_cloud_session(
         self, send_fn: Callable[[], Awaitable[None]]
     ) -> None:
@@ -478,52 +462,32 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             await send_fn()
             return
 
-        app_id = await self._read_app_id()
-        self._revert_foreign_app_id_if_session_clear(app_id)
+        async with self._session_connect_lock:
+            app_id = await self._read_app_id()
+            self._revert_foreign_app_id_if_session_clear(app_id)
 
-        # When Coffee Link already holds the cloud session (app_id != 0 and != ours),
-        # we adopt its app_id so HA commands ride the same session instead of fighting
-        # the official app. The adoption is TRANSIENT: we never POST a foreign
-        # session, and we revert to our own id once the app releases it (see
-        # _update_session_from_props). If the user opens Coffee Link while HA
-        # is commanding, behaviour is undefined (the app may hold a LAN lock);
-        # close the app first.
-        if app_id not in (None, 0) and app_id != self._integration_app_id:
-            _LOGGER.info(
-                "Adopting foreign cloud session app_id=%d for dsn=%s",
-                app_id,
-                self.device.dsn,
-            )
-            self._integration_app_id = app_id
-            self._last_connect_at = time.time()
+            # Ride an existing official-app session without registering it as ours.
+            if app_id not in (None, 0) and app_id != self._integration_app_id:
+                self._integration_app_id = app_id
+                self._last_connect_at = time.time()
+            elif self._session_is_fresh(app_id):
+                if not self._session_confirmed:
+                    live_app_id, fetch_ok = await self._fetch_app_id_live()
+                    if not fetch_ok or live_app_id != self._integration_app_id:
+                        raise HomeAssistantError(
+                            "The cached Coffee Link cloud session could not be verified"
+                        )
+            else:
+                await self._post_cloud_session()
+                await asyncio.sleep(CONNECT_SETTLE_DELAY)
+                if not await self._wait_for_session_confirmed():
+                    self.last_command_result = "timed_out"
+                    raise HomeAssistantError(
+                        "Timed out while acquiring the Coffee Link cloud session"
+                    )
+                self._last_connect_at = time.time()
+
             await send_fn()
-            return
-
-        if self._session_is_fresh(app_id):
-            _LOGGER.debug("Cloud session warm cache hit for dsn=%s", self.device.dsn)
-            await send_fn()
-            return
-
-        if self._session_cold_task and not self._session_cold_task.done():
-            _LOGGER.warning(
-                "Cloud session connect already in progress for dsn=%s; "
-                "ignoring duplicate command (confirm timeout=%ds)",
-                self.device.dsn,
-                CONNECT_CONFIRM_TIMEOUT,
-            )
-            return
-
-        _LOGGER.debug(
-            "Scheduling cloud session connect for dsn=%s (confirm timeout=%ds)",
-            self.device.dsn,
-            CONNECT_CONFIRM_TIMEOUT,
-        )
-        # Each command gets its own task; the connect lock serializes them, so
-        # commands pressed during a cold connect are queued, not dropped.
-        self._session_cold_task = self.hass.async_create_background_task(
-            self._cold_connect_then(send_fn),
-            "delonghi cloud session cold connect",
-        )
 
     # ------------------------------------------------------------------ #
     # Command sniffer
@@ -582,23 +546,26 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.last_captured_command = decoded
             if origin == "app":
                 self._maybe_learn_frame(decoded)
-            summary = summarize_decoded(decoded)
+            summary = (
+                f"type={decoded.get('type')} style={decoded.get('style')} "
+                f"beverage={decoded.get('beverage_name')} "
+                f"action={decoded.get('action_name')} crc_valid={decoded.get('crc_valid')}"
+            )
             if origin == "app":
                 _LOGGER.warning(
-                    "CAPTURED app->machine command on %s (dsn=%s): %s | %s",
-                    prop_name, self.device.dsn, value, summary,
+                    "Captured app-to-machine command on %s: %s",
+                    prop_name,
+                    summary,
                 )
             else:
-                _LOGGER.debug(
-                    "Observed own command echoed on %s: %s | %s",
-                    prop_name, value, summary,
-                )
+                _LOGGER.debug("Observed own command echoed on %s: %s", prop_name, summary)
         else:
             decoded["captured_at"] = prop.get("data_updated_at")
             self.last_machine_response = decoded
             _LOGGER.debug(
-                "Machine->app response on %s (dsn=%s): %s | %s",
-                prop_name, self.device.dsn, value, summarize_decoded(decoded),
+                "Machine-to-app response on %s: type=%s",
+                prop_name,
+                decoded.get("type"),
             )
 
     def _record_sent(self, value: str) -> None:
@@ -633,16 +600,14 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     replay_with_timestamp(self.learned_wake_frame)
                 ):
                     _LOGGER.warning(
-                        "Discarding persisted wake frame (integrity check failed): %s. "
+                        "Discarding persisted wake frame (integrity check failed). "
                         "Power the machine on once from the official app to re-learn it.",
-                        self.learned_wake_frame,
                     )
                     self.learned_wake_frame = None
             elif not is_wake_power_frame(decode_command(self.learned_wake_frame)):
                 _LOGGER.warning(
-                    "Discarding persisted wake frame (not a real power-on): %s. "
+                    "Discarding persisted wake frame (not a real power-on). "
                     "Power the machine on once from the official app to re-learn it.",
-                    self.learned_wake_frame,
                 )
                 self.learned_wake_frame = None
         total = (
@@ -651,9 +616,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             + (1 if self.learned_wake_frame else 0)
         )
         if total:
-            _LOGGER.debug(
-                "Restored %d learned Eletta frame(s) for dsn=%s", total, self.device.dsn
-            )
+            _LOGGER.debug("Restored %d learned command frame(s)", total)
+        self._restore_device_app_id()
 
     def log_recipe_datapoints(self) -> None:
         """Dump the machine's stored recipe datapoints to the log (read-only).
@@ -665,14 +629,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not self.data:
             _LOGGER.warning("Recipe dump requested but no data fetched yet.")
             return
-        lines = recipe_dump_lines(self.data)
-        _LOGGER.warning(
-            "=== DeLonghi recipe datapoint dump (dsn=%s, %d entries) BEGIN ===\n"
-            "%s\n=== recipe datapoint dump END ===",
-            self.device.dsn,
-            len(lines),
-            "\n".join(lines),
-        )
+        names = [line.partition(" = ")[0] for line in recipe_dump_lines(self.data)]
+        _LOGGER.warning("Recipe datapoints detected: %s", ", ".join(names))
 
     def _learned_storage_data(self) -> dict:
         """Callback for the debounced Store save."""
@@ -713,13 +671,14 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 return
             if self.learned_wake_frame != raw_b64:
                 self.learned_wake_frame = raw_b64
-                _LOGGER.info("Learned %s wake/power-on frame: %s", self.profile.key, raw_b64)
+                self._restore_device_app_id()
+                _LOGGER.info("Learned a %s wake/power-on frame", self.profile.key)
                 self._store.async_delay_save(
                     self._learned_storage_data, RECIPE_STORE_SAVE_DELAY
                 )
             return
 
-        if ftype != "beverage" or decoded.get("style") != "eletta":
+        if ftype != "beverage":
             return
         bev_hex = decoded.get("beverage_id")
         if not bev_hex:
@@ -728,6 +687,11 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             bev_id = int(bev_hex, 16)
         except (ValueError, TypeError):
             return
+        if decoded.get("action") == ACTION_STOP:
+            if self.active_beverage_id == bev_id:
+                self.active_beverage_id = None
+        else:
+            self.active_beverage_id = bev_id
         table = (
             self.learned_stop_frames
             if decoded.get("action") == ACTION_STOP
@@ -735,13 +699,13 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         )
         if table.get(bev_id) != raw_b64:
             table[bev_id] = raw_b64
+            self._restore_device_app_id()
             _LOGGER.info(
-                "Learned %s %s frame for beverage 0x%02x (%s): %s",
+                "Learned a %s %s frame for beverage 0x%02x (%s)",
                 self.profile.key,
                 "stop" if decoded.get("action") == ACTION_STOP else "start",
                 bev_id,
                 decoded.get("beverage_name"),
-                raw_b64,
             )
             self._store.async_delay_save(
                 self._learned_storage_data, RECIPE_STORE_SAVE_DELAY
@@ -758,37 +722,72 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             learned = table.get(beverage_id)
             value = self.profile.beverage_value(beverage_id, action, learned)
             if value is None:
+                if self.profile.learns_from_app:
+                    raise HomeAssistantError(
+                        "This command is unavailable until its frame has been learned "
+                        "from the official Coffee Link app"
+                    )
                 value = build_and_encode(beverage_id, action)
-                _LOGGER.warning(
-                    "No learned %s frame for beverage 0x%02x yet (%s). Trigger this "
-                    "drink once from the official Coffee Link app so Home Assistant "
-                    "can capture and replay its exact bytes. Sending a best-effort "
-                    "frame meanwhile (the machine will likely ignore it).",
-                    "stop" if action == ACTION_STOP else "start",
-                    beverage_id,
-                    self.profile.label,
-                )
-            else:
-                _LOGGER.info(
-                    "Sending %s beverage 0x%02x (%s): %s",
-                    self.profile.key,
-                    beverage_id,
-                    "stop" if action == ACTION_STOP else "start",
-                    value,
-                )
-            self._record_sent(value)
-            prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-            _LOGGER.info(
-                "Sending beverage cmd via %s: bev_id=0x%02x action=%d value=%s",
-                prop,
-                beverage_id,
-                action,
+            await self._send_property_command(
                 value,
+                f"beverage 0x{beverage_id:02x} action {action}",
             )
-            await self.client.async_set_property_value(self.device.dsn, prop, value)
-            await self.async_request_refresh()
 
-        await self._with_cloud_session(_do)
+        await self._run_command_transaction(_do)
+        if action == ACTION_STOP:
+            if self.active_beverage_id == beverage_id:
+                self.active_beverage_id = None
+        else:
+            self.active_beverage_id = beverage_id
+        self.async_update_listeners()
+
+    async def async_stop_active_beverage(self) -> None:
+        """Stop the tracked active beverage without guessing an identifier."""
+        if self.active_beverage_id is None:
+            self.last_command_result = "rejected"
+            raise HomeAssistantError(
+                "The active beverage is unknown; start a drink before using Stop"
+            )
+        await self.async_send_beverage(self.active_beverage_id, ACTION_STOP)
+
+    async def _run_command_transaction(
+        self, send_fn: Callable[[], Awaitable[None]]
+    ) -> None:
+        """Serialize one complete connect, write and confirmation transaction."""
+        if self._command_lock.locked():
+            self.last_command_result = "rejected"
+            raise HomeAssistantError(
+                "Another coffee maker command is still in progress; try again shortly"
+            )
+
+        async with self._command_lock:
+            self.last_command_result = "pending"
+            try:
+                await self._with_cloud_session(send_fn)
+            except ConfigEntryAuthFailed:
+                self.last_command_result = "rejected"
+                raise
+            except AuthError as err:
+                self.last_command_result = "rejected"
+                raise ConfigEntryAuthFailed(
+                    "Coffee Link credentials are no longer valid"
+                ) from err
+            except HomeAssistantError:
+                if self.last_command_result != "timed_out":
+                    self.last_command_result = "rejected"
+                raise
+            except (CloudError, asyncio.TimeoutError) as err:
+                self.last_command_result = "timed_out"
+                raise HomeAssistantError(
+                    "The Coffee Link cloud command could not be completed"
+                ) from err
+            except Exception as err:
+                self.last_command_result = "rejected"
+                raise HomeAssistantError(
+                    "The coffee maker command failed before completion"
+                ) from err
+            if self.last_command_result not in {"sent", "acknowledged"}:
+                self.last_command_result = "sent"
 
     async def async_send_wake(self) -> None:
         """Send the WAKE / power-on command to bring the machine out of standby."""
@@ -797,34 +796,25 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             async def _do() -> None:
                 value = self.profile.wake_value(self.learned_wake_frame)
                 if value is None:
+                    if self.profile.learns_from_app:
+                        raise HomeAssistantError(
+                            "Wake is unavailable until its frame has been learned "
+                            "from the official Coffee Link app"
+                        )
                     value = build_wake_encoded()
-                    _LOGGER.warning(
-                        "No learned wake frame for this %s yet. Power the machine on once "
-                        "from the official Coffee Link app so Home Assistant can capture "
-                        "and replay it. Sending a best-effort synthesized wake meanwhile "
-                        "(the machine will likely ignore it - it lacks the device "
-                        "signature the app appends).",
-                        self.profile.label,
-                    )
-                self._record_sent(value)
-                prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-                _LOGGER.info("Sending WAKE cmd via %s: %s", prop, value)
-                await self.client.async_set_property_value(self.device.dsn, prop, value)
-                await self.async_request_refresh()
+                await self._send_property_command(value, "WAKE command")
 
-            await self._with_cloud_session(_do)
+            await self._run_command_transaction(_do)
             return
 
         async def _do() -> None:
             await self._maybe_send_session_refresh()
-            value = self._wake_command_value()
-            await self._send_property_command(value, "WAKE cmd")
+            await self._send_property_command(self._wake_command_value(), "WAKE command")
 
-        await self._with_cloud_session(_do)
+        await self._run_command_transaction(_do)
 
     def _learned_device_signature(self) -> bytes | None:
-        """The 4-byte per-device signature carried by learned app frames (the
-        wake frame first, else any learned beverage frame)."""
+        """Return the device signature carried by any learned app frame."""
         from .command_builder import device_signature_from_frame
 
         for frame in (
@@ -832,54 +822,53 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             *self.learned_start_frames.values(),
             *self.learned_stop_frames.values(),
         ):
-            sig = device_signature_from_frame(frame)
-            if sig is not None:
-                return sig
+            signature = device_signature_from_frame(frame)
+            if signature is not None:
+                return signature
         return None
 
-    async def async_send_standby(self) -> None:
-        """Send the STANDBY / power-off command (84 0f, params 01 01).
+    def _restore_device_app_id(self) -> None:
+        """Use the learned per-device signature for ECAM cloud sessions."""
+        if not self.profile.uses_cloud_session:
+            return
+        signature = self._learned_device_signature()
+        if signature is None:
+            return
+        app_id = normalize_signed_app_id(int.from_bytes(signature, "big"))
+        self._default_app_id = app_id
+        self._integration_app_id = app_id
 
-        Always synthesized - the official app has no power-off control to
-        capture. Validated live on the reference Soul; on learn-and-replay
-        models the per-device signature from a learned frame is appended.
-        """
+    async def async_send_standby(self) -> None:
+        """Send the STANDBY / power-off command."""
         if not self.profile.uses_cloud_session:
 
             async def _do() -> None:
                 value = self.profile.standby_value(self._learned_device_signature())
                 if value is None:
+                    if self.profile.learns_from_app:
+                        raise HomeAssistantError(
+                            "Standby is unavailable until a device signature has been learned"
+                        )
                     value = build_standby_encoded()
-                    _LOGGER.warning(
-                        "No learned frame for this %s yet, so the standby command is "
-                        "sent without the device signature and the machine may ignore "
-                        "it. Trigger any command once from the official Coffee Link "
-                        "app (e.g. power-on) so Home Assistant can learn the signature.",
-                        self.profile.label,
-                    )
-                self._record_sent(value)
-                prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-                _LOGGER.info("Sending STANDBY cmd via %s: %s", prop, value)
-                await self.client.async_set_property_value(self.device.dsn, prop, value)
-                await self.async_request_refresh()
+                await self._send_property_command(value, "STANDBY command")
 
-            await self._with_cloud_session(_do)
+            await self._run_command_transaction(_do)
             return
 
         async def _do() -> None:
-            value = self._standby_command_value()
-            await self._send_property_command(value, "STANDBY cmd")
+            await self._send_property_command(
+                self._standby_command_value(), "STANDBY command"
+            )
 
-        await self._with_cloud_session(_do)
+        await self._run_command_transaction(_do)
 
     async def async_send_raw(self, value: str) -> None:
-        """Send a raw base64 command on the resolved command channel (advanced)."""
+        """Validate and send a raw base64 command (administrator-only action)."""
+        if "error" in decode_command(value):
+            self.last_command_result = "rejected"
+            raise HomeAssistantError("The raw command is not a valid base64 protocol frame")
 
         async def _do() -> None:
-            self._record_sent(value)
-            prop = self.command_property or COMMAND_PROPERTY_CANDIDATES[0]
-            _LOGGER.info("Sending RAW cmd via %s: %s", prop, value)
-            await self.client.async_set_property_value(self.device.dsn, prop, value)
-            await self.async_request_refresh()
+            await self._send_property_command(value, "RAW command")
 
-        await self._with_cloud_session(_do)
+        await self._run_command_transaction(_do)

--- a/custom_components/delonghi_coffeelink/diagnostics.py
+++ b/custom_components/delonghi_coffeelink/diagnostics.py
@@ -1,0 +1,50 @@
+"""Privacy-safe diagnostics for DeLonghi Coffee Link."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
+
+from . import DelonghiRuntimeData
+from .const import DOMAIN
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry[DelonghiRuntimeData]
+) -> dict[str, Any]:
+    """Return diagnostics without credentials, identifiers, values or raw frames."""
+    integration = await async_get_integration(hass, DOMAIN)
+    devices: list[dict[str, Any]] = []
+    for coordinator in entry.runtime_data.coordinators:
+        devices.append(
+            {
+                "model": coordinator.device.model,
+                "oem_model": coordinator.device.oem_model,
+                "software_version": coordinator.device.sw_version,
+                "profile": coordinator.profile.key,
+                "connection_status": coordinator.device.connection_status,
+                "detected_properties": {
+                    "command": coordinator.command_property,
+                    "response": coordinator.response_property,
+                    "connected": coordinator.connected_property,
+                },
+                "property_names": sorted((coordinator.data or {}).keys()),
+                "coordinator": {
+                    "last_update_success": coordinator.last_update_success,
+                    "last_command_result": coordinator.last_command_result,
+                    "active_beverage_known": coordinator.active_beverage_id is not None,
+                    "monitor_status": coordinator.monitor.get("status_name"),
+                },
+            }
+        )
+    return {
+        "integration": {
+            "domain": DOMAIN,
+            "version": integration.version,
+            "config_entry_version": entry.version,
+        },
+        "devices": devices,
+    }

--- a/custom_components/delonghi_coffeelink/sensor.py
+++ b/custom_components/delonghi_coffeelink/sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -24,12 +24,9 @@ from .const import (
     COUNTER_SENSORS,
     DOMAIN,
     INFO_SENSORS,
-    INTEGRATION_CLOUD_APP_ID,
     MANUFACTURER,
 )
 from .coordinator import DelonghiCoordinator
-
-_HA_CLOUD_SESSION_APP_ID = normalize_signed_app_id(INTEGRATION_CLOUD_APP_ID)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,7 +49,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    coordinators: list[DelonghiCoordinator] = hass.data[DOMAIN][entry.entry_id]
+    coordinators = entry.runtime_data.coordinators
     entities: list[SensorEntity] = []
     for coord in coordinators:
         for candidates, key, _friendly, icon in COUNTER_SENSORS:
@@ -242,22 +239,8 @@ def _parse_cloud_session_app_id(raw: Any) -> int | None:
         return None
 
 
-def _cloud_session_holder(app_id: int | None) -> str:
-    if app_id is None:
-        return "unknown"
-    if app_id == 0:
-        return "free"
-    if app_id == _HA_CLOUD_SESSION_APP_ID:
-        return "ha"
-    return "foreign"
-
-
 class DelonghiCloudSessionAppIdSensor(_Base):
-    """Diagnostic: machine property ``app_id`` (current cloud session holder).
-
-    Unlike ``Last Connected`` (``app_device_connected``), this is the slot the
-    official Coffee Link app checks before connecting — not the last connect POST.
-    """
+    """Privacy-safe diagnostic for the current cloud-session holder."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -267,30 +250,17 @@ class DelonghiCloudSessionAppIdSensor(_Base):
         )
 
     @property
-    def native_value(self) -> int | None:
+    def native_value(self) -> str:
         prop = (self.coordinator.data or {}).get(APP_ID_PROPERTY)
         if not isinstance(prop, dict):
-            return None
-        return _parse_cloud_session_app_id(prop.get("value"))
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        app_id = self.native_value
-        attrs: dict[str, Any] = {"holder": _cloud_session_holder(app_id)}
-        if app_id is not None:
-            attrs["app_id_hex"] = f"{app_id & 0xFFFFFFFF:08x}"
-        return attrs
+            return "unknown"
+        return self.coordinator.cloud_session_holder(
+            _parse_cloud_session_app_id(prop.get("value"))
+        )
 
 
 class DelonghiLastCommandSensor(_Base):
-    """Diagnostic: last command seen on the binary channel.
-
-    Surfaces the command sniffer (see coordinator). When the official Coffee
-    Link app sends a command, its exact base64 bytes appear here as the state,
-    decoded in the attributes - including ``matches_integration`` which tells
-    whether the app's bytes match what this integration would generate. This is
-    the ground-truth needed to debug models where commands are silently ignored.
-    """
+    """Privacy-safe diagnostic result for the latest command transaction."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -300,12 +270,8 @@ class DelonghiLastCommandSensor(_Base):
         )
 
     @property
-    def native_value(self) -> str | None:
-        rec = self.coordinator.last_captured_command
-        if not rec:
-            return None
-        # Frames are short (<= ~24 base64 chars), well within the 255 limit.
-        return rec.get("raw_b64")
+    def native_value(self) -> str:
+        return self.coordinator.last_command_result
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -315,22 +281,13 @@ class DelonghiLastCommandSensor(_Base):
             "type",
             "style",
             "beverage_name",
-            "beverage_id",
             "action_name",
-            "recipe",
-            "params",
-            "crc",
             "crc_valid",
             "matches_integration",
-            "builder_structural_b64",
-            "structural_b64",
-            "timestamp",
             "captured_at",
-            "hex",
         )
         attrs = {k: rec[k] for k in keys if k in rec}
         resp = self.coordinator.last_machine_response
         if resp:
-            attrs["last_machine_response_hex"] = resp.get("hex")
             attrs["last_machine_response_at"] = resp.get("captured_at")
         return attrs

--- a/custom_components/delonghi_coffeelink/services.yaml
+++ b/custom_components/delonghi_coffeelink/services.yaml
@@ -1,6 +1,9 @@
 start_beverage:
   name: Start Beverage
   description: Start brewing a specific beverage on the connected DeLonghi machine.
+  target:
+    device:
+      integration: delonghi_coffeelink
   fields:
     beverage:
       name: Beverage
@@ -34,12 +37,15 @@ start_beverage:
 
 stop_beverage:
   name: Stop Beverage
-  description: Send a stop command for the given beverage.
+  description: Stop the active beverage, or the explicitly selected beverage.
+  target:
+    device:
+      integration: delonghi_coffeelink
   fields:
     beverage:
       name: Beverage
       description: Beverage key
-      required: true
+      required: false
       example: hot_water
       selector:
         select:
@@ -54,6 +60,9 @@ stop_beverage:
 send_raw_command:
   name: Send Raw Command
   description: Send a raw base64-encoded binary command to data_request (advanced).
+  target:
+    device:
+      integration: delonghi_coffeelink
   fields:
     value_base64:
       name: Command (base64)

--- a/custom_components/delonghi_coffeelink/strings.json
+++ b/custom_components/delonghi_coffeelink/strings.json
@@ -8,6 +8,13 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect DeLonghi Coffee Link",
+        "description": "Enter the current password for {email}.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -17,7 +24,8 @@
       "unknown": "Unexpected error."
     },
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Reauthentication was successful."
     }
   },
   "entity": {
@@ -137,10 +145,10 @@
         "name": "Machine Status"
       },
       "cloud_session_app_id": {
-        "name": "Cloud Session app_id"
+        "name": "Cloud Session Holder"
       },
       "last_captured_command": {
-        "name": "Last Captured Command"
+        "name": "Last Command Result"
       }
     },
     "button": {

--- a/custom_components/delonghi_coffeelink/translations/en.json
+++ b/custom_components/delonghi_coffeelink/translations/en.json
@@ -8,6 +8,13 @@
           "email": "Email",
           "password": "Password"
         }
+      },
+      "reauth_confirm": {
+        "title": "Reconnect DeLonghi Coffee Link",
+        "description": "Enter the current password for {email}.",
+        "data": {
+          "password": "Password"
+        }
       }
     },
     "error": {
@@ -17,7 +24,8 @@
       "unknown": "Unexpected error."
     },
     "abort": {
-      "already_configured": "This account is already configured."
+      "already_configured": "This account is already configured.",
+      "reauth_successful": "Reauthentication was successful."
     }
   },
   "entity": {
@@ -137,10 +145,10 @@
         "name": "Machine Status"
       },
       "cloud_session_app_id": {
-        "name": "Cloud Session app_id"
+        "name": "Cloud Session Holder"
       },
       "last_captured_command": {
-        "name": "Last Captured Command"
+        "name": "Last Command Result"
       }
     },
     "button": {

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,0 +1,447 @@
+"""Regression tests for truthful and serialized command execution."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PKG_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "delonghi_coffeelink"
+PKG_NAME = "delonghi_reliability_tests"
+
+
+class HomeAssistantError(Exception):
+    """Test double for Home Assistant's user-visible error."""
+
+
+class ConfigEntryAuthFailed(Exception):
+    """Test double for Home Assistant's reauth signal."""
+
+
+class DataUpdateCoordinator:
+    """Small test double sufficient for constructing the coordinator."""
+
+    @classmethod
+    def __class_getitem__(cls, item):
+        return cls
+
+    def __init__(self, hass, logger, *, name, update_interval):
+        self.hass = hass
+        self.data = {}
+        self.last_update_success = True
+
+    async def async_shutdown(self):
+        return None
+
+    async def async_request_refresh(self):
+        return None
+
+    def async_update_listeners(self):
+        return None
+
+
+class Store:
+    def __init__(self, hass, version, key):
+        pass
+
+
+def _install_homeassistant_stubs() -> None:
+    voluptuous = types.ModuleType("voluptuous")
+    voluptuous.Schema = lambda value: value
+    voluptuous.Required = lambda value: value
+    voluptuous.Optional = lambda value: value
+    voluptuous.All = lambda *values: values[-1]
+    voluptuous.In = lambda values: values
+    homeassistant = types.ModuleType("homeassistant")
+    core = types.ModuleType("homeassistant.core")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    data_entry_flow = types.ModuleType("homeassistant.data_entry_flow")
+    exceptions = types.ModuleType("homeassistant.exceptions")
+    constants = types.ModuleType("homeassistant.const")
+    helpers = types.ModuleType("homeassistant.helpers")
+    config_validation = types.ModuleType("homeassistant.helpers.config_validation")
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    service = types.ModuleType("homeassistant.helpers.service")
+    typing_module = types.ModuleType("homeassistant.helpers.typing")
+    storage = types.ModuleType("homeassistant.helpers.storage")
+    update = types.ModuleType("homeassistant.helpers.update_coordinator")
+    aiohttp_client = types.ModuleType("homeassistant.helpers.aiohttp_client")
+    loader = types.ModuleType("homeassistant.loader")
+
+    class ConfigEntry:
+        @classmethod
+        def __class_getitem__(cls, item):
+            return cls
+
+    class ConfigEntryState:
+        LOADED = "loaded"
+
+    class Platform:
+        SENSOR = "sensor"
+        BINARY_SENSOR = "binary_sensor"
+        BUTTON = "button"
+
+    class ConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            return super().__init_subclass__()
+
+        def __init__(self):
+            self.hass = object()
+            self._reauth_entry = None
+
+        def _get_reauth_entry(self):
+            return self._reauth_entry
+
+        def async_show_form(self, **kwargs):
+            return {"type": "form", **kwargs}
+
+        def async_update_reload_and_abort(self, entry, *, data_updates):
+            return {
+                "type": "abort",
+                "reason": "reauth_successful",
+                "entry": entry,
+                "data_updates": data_updates,
+            }
+
+    async def async_get_integration(hass, domain):
+        return types.SimpleNamespace(version="0.3.16")
+
+    core.HomeAssistant = object
+    core.ServiceCall = object
+    config_entries.ConfigEntry = ConfigEntry
+    config_entries.ConfigEntryState = ConfigEntryState
+    config_entries.ConfigFlow = ConfigFlow
+    constants.ATTR_DEVICE_ID = "device_id"
+    constants.Platform = Platform
+    data_entry_flow.FlowResult = dict
+    exceptions.HomeAssistantError = HomeAssistantError
+    exceptions.ConfigEntryAuthFailed = ConfigEntryAuthFailed
+    exceptions.ConfigEntryNotReady = RuntimeError
+    config_validation.ensure_list = lambda value: value if isinstance(value, list) else [value]
+    config_validation.string = str
+    device_registry.async_get = lambda hass: hass.device_registry
+    service.async_register_admin_service = lambda *args, **kwargs: None
+    typing_module.ConfigType = dict
+    helpers.config_validation = config_validation
+    helpers.device_registry = device_registry
+    storage.Store = Store
+    update.DataUpdateCoordinator = DataUpdateCoordinator
+    update.UpdateFailed = RuntimeError
+    loader.async_get_integration = async_get_integration
+    aiohttp_client.async_get_clientsession = lambda hass: object()
+    homeassistant.config_entries = config_entries
+    sys.modules.update(
+        {
+            "voluptuous": voluptuous,
+            "homeassistant": homeassistant,
+            "homeassistant.core": core,
+            "homeassistant.const": constants,
+            "homeassistant.config_entries": config_entries,
+            "homeassistant.data_entry_flow": data_entry_flow,
+            "homeassistant.exceptions": exceptions,
+            "homeassistant.helpers": helpers,
+            "homeassistant.helpers.config_validation": config_validation,
+            "homeassistant.helpers.device_registry": device_registry,
+            "homeassistant.helpers.service": service,
+            "homeassistant.helpers.typing": typing_module,
+            "homeassistant.helpers.storage": storage,
+            "homeassistant.helpers.update_coordinator": update,
+            "homeassistant.helpers.aiohttp_client": aiohttp_client,
+            "homeassistant.loader": loader,
+        }
+    )
+
+
+_install_homeassistant_stubs()
+package = types.ModuleType(PKG_NAME)
+package.__path__ = [str(PKG_DIR)]
+package.DelonghiRuntimeData = type("DelonghiRuntimeData", (), {})
+sys.modules[PKG_NAME] = package
+
+
+def _load(name: str):
+    full_name = f"{PKG_NAME}.{name}"
+    spec = importlib.util.spec_from_file_location(full_name, PKG_DIR / f"{name}.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+const = _load("const")
+command_builder = _load("command_builder")
+ayla_client = _load("ayla_client")
+model_profiles = _load("model_profiles")
+_load("monitor")
+coordinator_module = _load("coordinator")
+diagnostics_module = _load("diagnostics")
+config_flow_module = _load("config_flow")
+
+
+def _load_integration_init():
+    full_name = f"{PKG_NAME}.integration_init"
+    spec = importlib.util.spec_from_file_location(full_name, PKG_DIR / "__init__.py")
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[full_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+integration_module = _load_integration_init()
+
+
+class FakeClient:
+    def __init__(self):
+        self.writes: list[tuple[str, str, str]] = []
+        self.connect_posts = 0
+
+    async def async_set_property_value(self, dsn, prop, value):
+        self.writes.append((dsn, prop, value))
+
+    async def async_post_cloud_session(self, dsn, prop, app_id):
+        self.connect_posts += 1
+
+
+def _coordinator(oem_model: str = "DL-millcore"):
+    client = FakeClient()
+    device = ayla_client.AylaDevice(
+        dsn="private-device-id",
+        name="Machine",
+        oem_model=oem_model,
+        model="model",
+        sw_version="1",
+        lan_ip="",
+        connection_status="online",
+    )
+    coordinator = coordinator_module.DelonghiCoordinator(object(), client, device)
+    coordinator.command_property = "data_request"
+    return coordinator, client
+
+
+def test_duplicate_command_is_rejected_not_queued():
+    async def scenario():
+        coordinator, _client = _coordinator()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def first_send():
+            entered.set()
+            await release.wait()
+
+        first = asyncio.create_task(coordinator._run_command_transaction(first_send))
+        await entered.wait()
+
+        with pytest.raises(HomeAssistantError, match="still in progress"):
+            await coordinator._run_command_transaction(lambda: asyncio.sleep(0))
+
+        release.set()
+        await first
+        assert coordinator.last_command_result == "sent"
+
+    asyncio.run(scenario())
+
+
+def test_missing_learned_frame_is_rejected_without_write():
+    async def scenario():
+        coordinator, client = _coordinator()
+
+        class LearnOnlyProfile:
+            learns_from_app = True
+            uses_cloud_session = False
+
+            @staticmethod
+            def beverage_value(beverage_id, action, learned_frame):
+                return learned_frame
+
+        coordinator.profile = LearnOnlyProfile()
+        with pytest.raises(HomeAssistantError, match="until its frame has been learned"):
+            await coordinator.async_send_beverage(0x02, const.ACTION_START)
+
+        assert client.writes == []
+        assert coordinator.last_command_result == "rejected"
+
+    asyncio.run(scenario())
+
+
+def test_stop_uses_active_beverage_id():
+    async def scenario():
+        coordinator, client = _coordinator()
+        coordinator.active_beverage_id = 0x07
+
+        await coordinator.async_stop_active_beverage()
+
+        sent = command_builder.decode_command(client.writes[0][2])
+        assert sent["beverage_id"] == "0x07"
+        assert sent["action"] == const.ACTION_STOP
+        assert coordinator.active_beverage_id is None
+
+    asyncio.run(scenario())
+
+
+def test_cold_connect_is_awaited_before_property_write(monkeypatch):
+    async def scenario():
+        coordinator, client = _coordinator("DL-striker-cb")
+        coordinator.connected_property = "app_device_connected"
+        coordinator.data = {const.APP_ID_PROPERTY: {"value": 0}}
+        coordinator.learned_start_frames[0x02] = "DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh"
+        monkeypatch.setattr(coordinator_module, "CONNECT_SETTLE_DELAY", 0)
+
+        async def confirmed():
+            return True
+
+        coordinator._wait_for_session_confirmed = confirmed
+        await coordinator.async_send_beverage(0x02, const.ACTION_START)
+
+        assert client.connect_posts == 1
+        assert len(client.writes) == 1
+        assert coordinator.last_command_result == "sent"
+
+    asyncio.run(scenario())
+
+
+def test_cold_connect_timeout_is_visible_and_does_not_write(monkeypatch):
+    async def scenario():
+        coordinator, client = _coordinator("DL-striker-cb")
+        coordinator.connected_property = "app_device_connected"
+        coordinator.data = {const.APP_ID_PROPERTY: {"value": 0}}
+        coordinator.learned_start_frames[0x02] = "DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh"
+        monkeypatch.setattr(coordinator_module, "CONNECT_SETTLE_DELAY", 0)
+
+        async def timed_out():
+            return False
+
+        coordinator._wait_for_session_confirmed = timed_out
+        with pytest.raises(HomeAssistantError, match="Timed out"):
+            await coordinator.async_send_beverage(0x02, const.ACTION_START)
+
+        assert client.writes == []
+        assert coordinator.last_command_result == "timed_out"
+
+    asyncio.run(scenario())
+
+
+def test_known_eletta_signature_restores_device_specific_app_id():
+    coordinator, _client = _coordinator("DL-striker-cb")
+    captured = "DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh"
+    coordinator.learned_start_frames[0x02] = captured
+
+    coordinator._restore_device_app_id()
+
+    signature = command_builder.device_signature_from_frame(captured)
+    assert signature == bytes.fromhex("00 c5 86 21")
+    assert coordinator._integration_app_id == 12_944_929
+    assert base64.b64decode(captured)[-4:] == signature
+
+
+def test_downloaded_diagnostics_redact_credentials_and_identifiers():
+    async def scenario():
+        coordinator, _client = _coordinator("DL-striker-cb")
+        coordinator.data = {
+            "app_id": {"value": 12_944_929},
+            "data_request": {"value": "raw-secret-frame"},
+        }
+        coordinator.command_property = "data_request"
+        coordinator.last_captured_command = {"raw_b64": "raw-secret-frame"}
+        entry = types.SimpleNamespace(
+            runtime_data=types.SimpleNamespace(coordinators=[coordinator]),
+            version=1,
+            data={"email": "private@example.com", "password": "secret-password"},
+        )
+
+        diagnostics = await diagnostics_module.async_get_config_entry_diagnostics(
+            object(), entry
+        )
+        rendered = json.dumps(diagnostics)
+
+        for secret in (
+            "private@example.com",
+            "secret-password",
+            "private-device-id",
+            "raw-secret-frame",
+            "12944929",
+        ):
+            assert secret not in rendered
+        assert diagnostics["devices"][0]["property_names"] == [
+            "app_id",
+            "data_request",
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_reauth_rejects_bad_password_then_updates_existing_entry(monkeypatch):
+    class FakeAuthClient:
+        def __init__(self, session, email, password):
+            self.password = password
+
+        async def async_authenticate(self):
+            if self.password == "wrong":
+                raise ayla_client.AuthError("rejected")
+
+        async def async_get_devices(self):
+            return [types.SimpleNamespace(name="Machine")]
+
+    monkeypatch.setattr(config_flow_module, "DelonghiAylaClient", FakeAuthClient)
+    flow = config_flow_module.DelonghiConfigFlow()
+    entry = types.SimpleNamespace(
+        data={const.CONF_EMAIL: "private@example.com", const.CONF_PASSWORD: "old"}
+    )
+    flow._reauth_entry = entry
+
+    bad = asyncio.run(
+        flow.async_step_reauth_confirm({const.CONF_PASSWORD: "wrong"})
+    )
+    assert bad["type"] == "form"
+    assert bad["errors"] == {"base": "invalid_auth"}
+
+    good = asyncio.run(
+        flow.async_step_reauth_confirm({const.CONF_PASSWORD: "replacement"})
+    )
+    assert good["type"] == "abort"
+    assert good["reason"] == "reauth_successful"
+    assert good["entry"] is entry
+    assert good["data_updates"] == {const.CONF_PASSWORD: "replacement"}
+
+
+def test_device_target_resolves_exactly_one_coordinator():
+    coordinator_a, _client_a = _coordinator()
+    coordinator_b, _client_b = _coordinator()
+    coordinator_a.device.dsn = "device-a"
+    coordinator_b.device.dsn = "device-b"
+    runtime = integration_module.DelonghiRuntimeData(
+        client=object(), coordinators=[coordinator_a, coordinator_b]
+    )
+    entry = types.SimpleNamespace(
+        state="loaded",
+        runtime_data=runtime,
+    )
+    device = types.SimpleNamespace(
+        identifiers={(const.DOMAIN, "device-a")},
+    )
+
+    class Registry:
+        @staticmethod
+        def async_get(device_id):
+            return device if device_id == "ha-device-a" else None
+
+    hass = types.SimpleNamespace(
+        config_entries=types.SimpleNamespace(
+            async_entries=lambda domain: [entry],
+        ),
+        device_registry=Registry(),
+    )
+    call = types.SimpleNamespace(data={"device_id": ["ha-device-a"]})
+
+    assert integration_module._target_coordinator(hass, call) is coordinator_a
+
+    ambiguous = types.SimpleNamespace(data={"device_id": ["one", "two"]})
+    with pytest.raises(HomeAssistantError, match="exactly one"):
+        integration_module._target_coordinator(hass, ambiguous)


### PR DESCRIPTION
## Summary
- await and serialize the complete cloud-session/write/confirmation transaction
- reject concurrent commands explicitly; never synthesize a known-incompatible learned-frame command
- track the active beverage and stop that ID safely
- derive the ECAM cloud app ID from the learned device signature (the real frame gives 12944929)
- register actions once in `async_setup` and require exactly one device target; raw command is admin-only
- move coordinator/client state to typed `ConfigEntry.runtime_data`
- raise `ConfigEntryAuthFailed` and add reauthentication without duplicate entries
- add privacy-safe diagnostics and remove raw frames/app IDs from diagnostic entities and logs

## Home Assistant lifecycle note
The original issue proposed removing actions after the last unload. Current Home Assistant guidance instead requires actions to be registered once in `async_setup` and remain registered so unloaded automations can still be edited and validated. With no loaded target, the handler returns a clear error.

## Validation
- 97 pytest tests pass
- Ruff lint/import checks pass under the CI configuration from #23
- regression tests cover cold connect, timeout, duplicate rejection, missing learned frames, active-beverage Stop, exact device-specific app ID restoration, reauthentication, device targeting and diagnostics redaction
- existing Soul command tests remain green

Fixes #16