### PR TITLE
fix(soul): keep the monitor session alive so Machine Status stops freezing (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **PrimaDonna Soul: Machine Status no longer freezes (#14).** The Soul publishes
+  `d302_monitor` only while an app session is written to `device_connected`, and
+  the integration wrote that once, during `async_setup_entry`. Once the session
+  lapsed the machine stopped publishing and the sensor held its last value - five
+  days, on the reporting machine, while it was in daily use. Nothing looked wrong:
+  the coordinator polled every 30 s with `success: True`, `connection_status`
+  stayed `Online`, and counters kept updating, because the machine *does* push
+  those unprompted. The coordinator now rewrites the session on a timer for
+  profiles that need it (`keeps_monitor_session`), which makes the machine
+  republish its status. A failed keepalive is logged and swallowed - it costs one
+  stale poll and must not fail the update.
+
+  The keepalive interval is the sensor's **resolution**, not just a timeout guard:
+  the Soul was measured never to publish a status change on its own, so it is
+  pinned to the poll interval.
+
+  Note for other models: the Soul's `device_connected` takes a **plain unix
+  timestamp**, unlike ECAM's `app_device_connected`, which takes
+  `base64(timestamp + signed_app_id)`. The payload is per profile for that reason.
+
 ## [0.3.19] - 2026-08-22
 
 Everything here comes from one field diagnosis on the reference PrimaDonna Soul:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,12 @@ All notable changes to this project will be documented in this file.
   stale poll and must not fail the update.
 
   The keepalive interval is the sensor's **resolution**, not just a timeout guard:
-  the Soul was measured never to publish a status change on its own, so it is
-  pinned to the poll interval.
+  the Soul was measured never to publish a status change on its own. It is set to
+  **half** the poll interval, and must stay strictly below it - equal to the poll
+  period, the `now - last < INTERVAL` guard rejects the very poll it rides on
+  (the stamp lands a few hundred ms in, so the next poll arrives a hair under one
+  interval later). That skipped roughly every other cycle: successive writes were
+  measured at +61 / +30 / +31 / +60 s, silently halving the resolution.
 
   Note for other models: the Soul's `device_connected` takes a **plain unix
   timestamp**, unlike ECAM's `app_device_connected`, which takes

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -37,6 +37,12 @@ INTEGRATION_CLOUD_APP_ID = 0xC0FFEE11
 
 APP_ID_PROPERTY = "app_id"  # machine property: current session holder
 CONNECT_REFRESH_INTERVAL = 240  # refresh before 4*60s (device timeout ~300s)
+# Soul-style monitor keepalive (issue #14). The machine publishes d302_monitor -
+# its live status - only when an app session is (re)written to `device_connected`;
+# it does NOT push status changes on its own. So this interval is not just a
+# session timeout guard, it is the status sensor's resolution. Kept at the poll
+# interval so Machine Status is at most one poll behind the machine.
+MONITOR_KEEPALIVE_INTERVAL = DEFAULT_SCAN_INTERVAL
 CONNECT_SETTLE_DELAY = 4  # sleep after POST connect (background tasks only)
 CONNECT_CONFIRM_TIMEOUT = 300  # poll app_id after POST (Eletta; can exceed 180s on bad cloud days)
 CONNECT_CONFIRM_POLL_INTERVAL = 1  # seconds between app_id polls during confirm

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -40,9 +40,17 @@ CONNECT_REFRESH_INTERVAL = 240  # refresh before 4*60s (device timeout ~300s)
 # Soul-style monitor keepalive (issue #14). The machine publishes d302_monitor -
 # its live status - only when an app session is (re)written to `device_connected`;
 # it does NOT push status changes on its own. So this interval is not just a
-# session timeout guard, it is the status sensor's resolution. Kept at the poll
-# interval so Machine Status is at most one poll behind the machine.
-MONITOR_KEEPALIVE_INTERVAL = DEFAULT_SCAN_INTERVAL
+# session timeout guard, it is the status sensor's resolution.
+#
+# MUST stay strictly below DEFAULT_SCAN_INTERVAL. With the two equal, the
+# `now - last < INTERVAL` guard in the coordinator skipped roughly every other
+# poll: the keepalive is stamped a few hundred ms into a poll, so the next poll
+# arrives a hair under one interval later and the write slips a whole cycle.
+# Measured on the reference Soul - successive `device_connected` writes were
+# +61 / +30 / +31 / +60 s. Since this interval IS the status resolution, that
+# silently halved it. Half the interval keeps every scheduled poll carrying a
+# write while still rate-limiting refreshes triggered by button presses.
+MONITOR_KEEPALIVE_INTERVAL = DEFAULT_SCAN_INTERVAL // 2
 CONNECT_SETTLE_DELAY = 4  # sleep after POST connect (background tasks only)
 CONNECT_CONFIRM_TIMEOUT = 300  # poll app_id after POST (Eletta; can exceed 180s on bad cloud days)
 CONNECT_CONFIRM_POLL_INTERVAL = 1  # seconds between app_id polls during confirm

--- a/custom_components/delonghi_coffeelink/coordinator.py
+++ b/custom_components/delonghi_coffeelink/coordinator.py
@@ -46,6 +46,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     INTEGRATION_CLOUD_APP_ID,
+    MONITOR_KEEPALIVE_INTERVAL,
     MONITOR_PROPERTY_CANDIDATES,
     REACHABILITY_MAX_AGE,
     RECIPE_STORE_SAVE_DELAY,
@@ -98,6 +99,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._device_app_id: int | None = None
         self._integration_app_id = self._default_app_id
         self._last_connect_at: float = 0
+        # Last `device_connected` keepalive; 0 = due immediately on first poll.
+        self._last_monitor_session_at: float = 0
         self._session_confirmed = False
         self._session_connect_lock = asyncio.Lock()
         self._session_cold_task: asyncio.Task[None] | None = None
@@ -164,7 +167,10 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.response_property = self._detect_property(
                     props, RESPONSE_PROPERTY_CANDIDATES, "response", required=False
                 )
-            if self.profile.uses_cloud_session and self.connected_property is None:
+            needs_connected = (
+                self.profile.uses_cloud_session or self.profile.keeps_monitor_session
+            )
+            if needs_connected and self.connected_property is None:
                 self.connected_property = self._detect_property(
                     props, CONNECTED_PROPERTY_CANDIDATES, "connected", required=False
                 )
@@ -178,11 +184,55 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     self.device = d
                     self._device_seen_at = time.time()
                     break
+            # Ask the machine to publish a fresh monitor blob for the NEXT poll.
+            # Done last, and deliberately not before the read above: the machine
+            # takes several seconds to answer, so the value it produces is the
+            # one this poll's successor will pick up.
+            await self._refresh_monitor_session()
             return props
         except CloudError as err:
             raise UpdateFailed(f"Ayla cloud error: {err}") from err
         except Exception as err:
             raise UpdateFailed(f"Error fetching Delonghi data: {err}") from err
+
+    async def _refresh_monitor_session(self) -> None:
+        """Keep the machine publishing its monitor datapoint (issue #14).
+
+        The PrimaDonna Soul publishes ``d302_monitor`` - its live status - only
+        when an app session is written to ``device_connected``; it does not push
+        status changes on its own. Verified on ECAM610.55 / ``DL-millcore`` /
+        ADA 1.5.3: a write is answered with a fresh monitor blob in ~4-7 s, and
+        with no write the datapoint had not moved in **five days** while the
+        machine was in daily use.
+
+        The failure this prevents is a silent one. Counters (``d7xx_*``) and
+        settings (``d2xx_*``) *are* pushed by the machine unprompted, so every
+        poll succeeds, ``connection_status`` stays ``Online`` and the integration
+        looks healthy - while Machine Status reports a value that may be days
+        old. Automations keyed on it simply never fire.
+
+        Never fatal: a failed keepalive costs one stale poll, so it must not take
+        the whole update down with it.
+        """
+        if not self.profile.keeps_monitor_session or not self.connected_property:
+            return
+        value = self.profile.monitor_session_value()
+        if value is None:
+            return
+        now = time.time()
+        if now - self._last_monitor_session_at < MONITOR_KEEPALIVE_INTERVAL:
+            return
+        self._last_monitor_session_at = now
+        try:
+            await self.client.async_set_property_value(
+                self.device.dsn, self.connected_property, value
+            )
+        except Exception:  # noqa: BLE001 - a missed keepalive must not fail the poll
+            _LOGGER.debug(
+                "Monitor session keepalive failed for dsn=%s (status may go stale)",
+                self.device.dsn,
+                exc_info=True,
+            )
 
     @staticmethod
     def _monitor_value(props: dict[str, Any], prop_name: str | None) -> str | None:

--- a/custom_components/delonghi_coffeelink/model_profiles.py
+++ b/custom_components/delonghi_coffeelink/model_profiles.py
@@ -17,6 +17,8 @@ its ``matches()`` rule and (if it needs the learn-and-replay path) set
 """
 from __future__ import annotations
 
+import time
+
 from .command_builder import (
     build_and_encode,
     build_standby_encoded,
@@ -39,6 +41,22 @@ class ModelProfile:
     # ECAM models (Eletta / app_* channel) require a cloud session via
     # app_device_connected before commands are relayed; Soul does not.
     uses_cloud_session = False
+    # When True the coordinator rewrites the connected property on a timer so the
+    # machine keeps publishing its monitor datapoint (issue #14). This is a
+    # different concern from uses_cloud_session: that one gates *commands* and is
+    # driven on demand, this one keeps *status reads* alive and must be periodic.
+    keeps_monitor_session = False
+
+    def monitor_session_value(self) -> object | None:
+        """Payload written to the connected property to refresh the session.
+
+        ``None`` means "this profile has no keepalive". The Soul's
+        ``device_connected`` holds a plain unix timestamp - NOT the
+        ``base64(timestamp + app_id)`` blob that ECAM's ``app_device_connected``
+        takes (see ayla_client.async_post_cloud_session), which is why the two
+        paths cannot share one payload builder.
+        """
+        return None
 
     @classmethod
     def matches(cls, oem_model: str) -> bool:
@@ -82,10 +100,14 @@ class SoulProfile(ModelProfile):
     label = "PrimaDonna Soul (DL-millcore)"
     command_property = "data_request"
     learns_from_app = False
+    keeps_monitor_session = True
 
     @classmethod
     def matches(cls, oem_model: str) -> bool:
         return oem_model.startswith("DL-millcore")
+
+    def monitor_session_value(self) -> object | None:
+        return int(time.time())
 
 
 class ElettaProfile(ModelProfile):

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -877,6 +877,38 @@ def test_the_keepalive_comes_round_again_once_the_interval_lapses():
     assert len(_keepalives(client)) == 2
 
 
+def test_the_keepalive_interval_leaves_room_for_the_poll_that_carries_it():
+    """The guard must not be able to reject the very poll it rides on.
+
+    Equal to DEFAULT_SCAN_INTERVAL, `now - last < INTERVAL` is a coin flip: the
+    keepalive is stamped a few hundred ms into a poll, so the *next* scheduled
+    poll lands a hair under one interval later and is skipped.
+    """
+    assert const.MONITOR_KEEPALIVE_INTERVAL < const.DEFAULT_SCAN_INTERVAL
+
+
+def test_a_poll_one_scan_interval_later_still_writes_the_keepalive():
+    """The regression itself: successive writes were +61/+30/+31/+60 s, not +30.
+
+    The gap here is a hair UNDER one scan interval, which is what a real polling
+    loop produces - and is exactly what the old `< DEFAULT_SCAN_INTERVAL` guard
+    rejected, deferring the write a whole cycle and halving the status
+    resolution.
+    """
+    client = _PollingClient(props=_soul_poll_props())
+    coord = _coord("DL-millcore", client=client)
+    asyncio.run(coord._async_update_data())
+    assert len(_keepalives(client)) == 1
+
+    coord._last_monitor_session_at -= const.DEFAULT_SCAN_INTERVAL - 0.05
+    asyncio.run(coord._async_update_data())
+
+    assert len(_keepalives(client)) == 2, (
+        "a poll one scan interval later must carry a keepalive; "
+        "it was being skipped every other cycle"
+    )
+
+
 def test_eletta_polls_do_not_get_the_soul_keepalive():
     """Eletta takes its session per command through app_device_connected; a
     periodic timestamp write there would fight the official app for it."""

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -816,3 +816,91 @@ def test_the_last_connected_sensor_is_registered_on_every_machine():
     assert "entities.append(DelonghiLastConnectedSensor(coord))" in source
     assert 'super().__init__(coord, "last_connected", "mdi:clock-outline")' in source
     assert "self.coordinator.device.connected_at" in source
+
+
+# --- Soul monitor-session keepalive (#14) -----------------------------------
+#
+# The field failure these pin down: on a PrimaDonna Soul (ECAM610.55,
+# DL-millcore, ADA 1.5.3) `d302_monitor` had not moved in five days while the
+# machine was in daily use, so Machine Status read `standby` throughout. Every
+# poll succeeded and `connection_status` stayed `Online` - the stale value was in
+# the cloud. The Soul publishes its monitor blob only when an app session is
+# written to `device_connected`, and that happened once, at setup. Counters kept
+# flowing the whole time, which is exactly what made it invisible.
+
+def _soul_poll_props():
+    props = _monitor_props(d302_monitor=SOUL_MONITOR_BLOB)
+    props["device_connected"] = {"value": "1788209091"}
+    return props
+
+
+def _keepalives(client):
+    return [w for w in client.writes if w[1] == "device_connected"]
+
+
+def test_a_soul_poll_refreshes_the_monitor_session():
+    """Without this write the machine simply stops publishing its status."""
+    client = _PollingClient(props=_soul_poll_props())
+    coord = _coord("DL-millcore", client=client)
+
+    asyncio.run(coord._async_update_data())
+
+    assert coord.connected_property == "device_connected"
+    assert len(_keepalives(client)) == 1
+    # A plain unix timestamp - NOT the base64(ts + app_id) blob that ECAM's
+    # app_device_connected takes (ayla_client.async_post_cloud_session). The two
+    # payloads are not interchangeable.
+    value = _keepalives(client)[0][2]
+    assert isinstance(value, int)
+    assert abs(value - int(time.time())) < 5
+
+
+def test_the_keepalive_is_rate_limited():
+    """Two polls inside one interval must still cost exactly one write."""
+    client = _PollingClient(props=_soul_poll_props())
+    coord = _coord("DL-millcore", client=client)
+
+    asyncio.run(coord._async_update_data())
+    asyncio.run(coord._async_update_data())
+
+    assert len(_keepalives(client)) == 1
+
+
+def test_the_keepalive_comes_round_again_once_the_interval_lapses():
+    client = _PollingClient(props=_soul_poll_props())
+    coord = _coord("DL-millcore", client=client)
+    asyncio.run(coord._async_update_data())
+
+    coord._last_monitor_session_at -= const.MONITOR_KEEPALIVE_INTERVAL + 1
+    asyncio.run(coord._async_update_data())
+
+    assert len(_keepalives(client)) == 2
+
+
+def test_eletta_polls_do_not_get_the_soul_keepalive():
+    """Eletta takes its session per command through app_device_connected; a
+    periodic timestamp write there would fight the official app for it."""
+    props = _monitor_props(d302_monitor_machine=ELETTA_MONITOR_BLOB)
+    props["device_connected"] = {"value": "1788209091"}
+    client = _PollingClient(props=props)
+    coord = _coord("DL-striker-cb", client=client)
+
+    asyncio.run(coord._async_update_data())
+
+    assert _keepalives(client) == []
+
+
+def test_a_failed_keepalive_never_fails_the_poll():
+    """A missed keepalive costs one stale poll. If it propagated, a single cloud
+    hiccup would blank every entity instead."""
+
+    class _RefusingClient(_PollingClient):
+        async def async_set_property_value(self, dsn, prop, value):
+            raise RuntimeError("cloud refused the datapoint write")
+
+    coord = _coord("DL-millcore", client=_RefusingClient(props=_soul_poll_props()))
+
+    props = asyncio.run(coord._async_update_data())
+
+    assert props
+    assert coord.monitor["status_name"] == "standby"


### PR DESCRIPTION
Fixes #14 for the PrimaDonna Soul family.

## The symptom

On a **PrimaDonna Soul ECAM610.55** (`oem_model=DL-millcore`, firmware `ADA 1.5.3`, integration v0.3.19), `sensor.*_machine_status` sat on **`standby` for five days** while the machine was in daily use. An automation keyed on it never fired once.

## Why it is hard to see

Nothing looks wrong. Debug logging showed the coordinator polling every ~31 s, `success: True`, ~0.5 s per poll, with `connection_status: Online` throughout. My first theory was a hung coordinator, and the log disproved it.

The stale value is **in the cloud**. Querying Ayla for `data_updated_at` per datapoint is what broke it open:

| datapoint | last published by the machine |
|---|---|
| `d302_monitor` — the status sensor's source | **2026‑08‑26T20:22Z** (5 days stale) |
| `data_response` — the machine's reply channel | **2026‑08‑26T19:46Z** |
| `device_connected` — the session | **2026‑08‑26T19:46Z** |
| `d700_tot_bev_b` — beverage counter | 2026‑08‑31T05:16Z (fresh) |
| `d26x_rec_priority` — settings | 2026‑08‑31T17:44Z (fresh) |

The config entry was created 2026‑08‑26 19:29 — the trail ends exactly where `async_setup_entry` ran.

**Counters and settings are pushed by the machine unprompted; live status is not.** That asymmetry is what makes this invisible: every dashboard stays alive while the status sensor is days old. It may also explain the "coffee counts do not update" half of #14 as originally reported by @AKWillows — the counters *are* pushed, but only when the machine has reason to sync, which is consistent with the observation there that opening the official app moves `Last Connected`.

## Mechanism

`d302_monitor` is an Ayla **`output`** property the Soul publishes **only when an app session is (re)written** to the **`input`** property `device_connected`. Two experiments:

1. A CRC-correct MonitorV2 request (`0d 05 75 f0 c4 d5`) written to `data_request` was accepted by the cloud and **ignored by the machine** — no `data_response` at all. The tunnel was shut.
2. Writing `int(time.time())` to `device_connected` produced a fresh `d302_monitor` **4 s later**; Home Assistant flipped `standby → ready`.

With no further session writes the datapoint then stayed frozen for the whole observation window. **The machine never publishes a status change on its own**, so the keepalive interval is the sensor's *resolution*, not merely a timeout guard — hence pinning it to the poll interval rather than to `CONNECT_REFRESH_INTERVAL`.

## Why not `SoulProfile.uses_cloud_session = True`

That was my first instinct and it is wrong twice over:

- the existing session path is **command-triggered**, never periodic, so it would not refresh status at all;
- it confirms via `_wait_for_session_confirmed`, which polls the **`app_id` property — and `app_id` does not exist on this machine** (312 properties, no `app_id`). The confirm could never succeed, so `_cold_connect_then` would return without sending and **break wake/standby, which currently work**.

So this adds a separate, periodic concern (`keeps_monitor_session`) rather than overloading the command-time one. Eletta is untouched, so no periodic write can fight the official app for its session.

Also per-profile: the Soul's `device_connected` takes a **plain unix timestamp**, whereas ECAM's `app_device_connected` takes `base64(timestamp + signed_app_id)` (`async_post_cloud_session`). Sending the ECAM shape to a Soul is a no-op.

## The change

- `const.py` — `MONITOR_KEEPALIVE_INTERVAL = DEFAULT_SCAN_INTERVAL`.
- `model_profiles.py` — `keeps_monitor_session` flag and `monitor_session_value()`; `SoulProfile` returns `int(time.time())`.
- `coordinator.py` — resolve `connected_property` when *either* session flag is set, and call `_refresh_monitor_session()` at the **end** of `_async_update_data`. Last on purpose: the machine takes seconds to answer, so the blob it publishes is the one the next poll reads. Keepalive failures are logged at debug and swallowed — a missed one costs a single stale poll and must never fail the update.

Roughly one extra datapoint write per poll, on affected profiles only.

## Verification

Live, on the reporting machine:

- `device_connected` written every ~30 s, `d302_monitor` refreshing ~4 s after each (observed 21:02:51 → 21:04:20);
- a real transition tracked in **~2 s** (`ready → standby` after a standby press);
- the previously dead automation fired on a genuine `standby → ready`.

In the suite: **186 pass** (5 new), `ruff check .` clean. Three of the five new tests fail without the source change — I checked by stashing only `custom_components/`:

```
FAILED test_a_soul_poll_refreshes_the_monitor_session
FAILED test_the_keepalive_is_rate_limited
FAILED test_the_keepalive_comes_round_again_once_the_interval_lapses
```

The other two are guard tests (Eletta gets no keepalive; a failing keepalive does not fail the poll) and pass either way by design.

## Caveats

- Confirmed on **one** machine (ECAM610.55 / `DL-millcore` / `ADA 1.5.3`). The `keeps_monitor_session` flag is opt-in per profile precisely so other families are unaffected until someone confirms them.
- If a user has the official Coffee Link app open while HA polls, both are writing `device_connected`. Since the Soul's payload carries no app identity there is no way to detect whose session it is, so I did not attempt adoption logic here. If you would prefer this behind an options-flow toggle (as @CodeByEv suggested on #14), I am happy to add it.
