### PR TITLE
fix: one Ayla 504 must not flap every entity (and invent 25 coffees)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **One Ayla `504` no longer marks every entity unavailable - and no longer
+  invents a full sweep of beverage presses.** `async_get_properties` and
+  `async_get_devices` did a bare `session.get()` + `await resp.json()` with no
+  status check, so a gateway error carrying a `text/plain` body surfaced as an
+  unretryable `aiohttp.ContentTypeError`. The retry helper already existed and
+  already handled `{429, 502, 503, 504}` correctly - reading the body as text
+  *before* parsing - but its docstring said "Eletta session paths only" and the
+  two hot polling paths bypassed it. They now go through it.
+
+  This matters far more than a single failed poll suggests.
+  `CoordinatorEntity.available` is just `coordinator.last_update_success`, so
+  one `UpdateFailed` takes **every** entity of the device to `unavailable` and
+  the next poll writes them all back. Home Assistant's logbook renders **both**
+  edges of a `button` as "Pressed", because a button's state *is* its last-press
+  timestamp - so a single hiccup fabricates a complete list of beverages
+  "brewed", on a machine whose lifetime counters never moved. The numeric
+  counters flap too, but the logbook drops sensors carrying a unit, which is
+  exactly why the artifact looks button-specific and therefore believable.
+
+  Observed on an ECAM610.55: ten such blips in seven days, every one lasting
+  exactly one poll interval.
+
+### Added
+- `TRANSIENT_FAILURE_TOLERANCE` (3): behind the HTTP retry, the coordinator now
+  keeps serving the last good snapshot for up to three consecutive failed polls
+  before letting entities go unavailable. Never silent - each tolerated poll
+  logs a warning, so a genuine outage is visible from the first failure rather
+  than only after two minutes. The first refresh is never tolerated: with no
+  previous data there is nothing to serve, and setup must still fail with
+  `ConfigEntryNotReady`.
+
+  `async_set_property_value` is **deliberately left un-retried**. It is the
+  command channel; a blind POST retry there could brew two coffees. It already
+  checks `resp.status` before parsing, so it raises a clean `CloudError`.
+
 ## [0.3.19] - 2026-08-22
 
 Everything here comes from one field diagnosis on the reference PrimaDonna Soul:

--- a/custom_components/delonghi_coffeelink/ayla_client.py
+++ b/custom_components/delonghi_coffeelink/ayla_client.py
@@ -127,7 +127,14 @@ class DelonghiAylaClient:
         ok_status: frozenset[int] | set[int] | None = None,
         op: str = "",
     ) -> Any:
-        """HTTP request with transient retry (Eletta session paths only)."""
+        """HTTP request with transient retry.
+
+        Every Ayla call should come through here. It reads the body as text
+        *before* parsing, so a gateway error carrying a ``text/plain`` body
+        cannot blow up in ``resp.json()`` - which is precisely how 504s escaped
+        as an unretryable ``aiohttp.ContentTypeError`` while
+        ``async_get_properties`` / ``async_get_devices`` bypassed this helper.
+        """
         await self.async_ensure_auth()
         if ok_status is None:
             ok_status = frozenset({200, 201})
@@ -262,10 +269,8 @@ class DelonghiAylaClient:
 
     async def async_get_devices(self) -> list[AylaDevice]:
         """List all Ayla devices tied to this account."""
-        await self.async_ensure_auth()
         url = f"{AYLA_EU_ADS_URL}/apiv1/devices.json"
-        async with self._session.get(url, headers=self._auth_headers()) as resp:
-            data = await resp.json()
+        data = await self._request_json("GET", url, op="get_devices") or []
         devices: list[AylaDevice] = []
         for wrap in data:
             d = wrap.get("device", wrap)
@@ -285,10 +290,8 @@ class DelonghiAylaClient:
 
     async def async_get_properties(self, dsn: str) -> dict[str, Any]:
         """Fetch all properties of a device, keyed by property name."""
-        await self.async_ensure_auth()
         url = f"{AYLA_EU_ADS_URL}/apiv1/dsns/{dsn}/properties.json"
-        async with self._session.get(url, headers=self._auth_headers()) as resp:
-            data = await resp.json()
+        data = await self._request_json("GET", url, op="get_properties") or []
         props: dict[str, Any] = {}
         for item in data:
             p = item.get("property", {})

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -45,6 +45,18 @@ CONNECT_CONFIRM_POLL_INTERVAL = 1  # seconds between app_id polls during confirm
 CLOUD_HTTP_RETRY_COUNT = 2
 CLOUD_HTTP_RETRY_BACKOFF = 1.5  # seconds; multiplied by attempt index
 CLOUD_TRANSIENT_HTTP_CODES = frozenset({429, 502, 503, 504})
+# Second line of defence, behind the HTTP retry above: keep serving the last good
+# data for this many CONSECUTIVE failed polls before admitting the device is
+# unavailable (~2 min at a 30 s interval).
+#
+# A coordinator's failure blast radius is every entity it owns. One UpdateFailed
+# takes every non-numeric entity of the device `-> unavailable` and the next poll
+# writes them all back - and Home Assistant's logbook renders BOTH edges of a
+# `button` as "Pressed", because a button's state IS its last-press timestamp. So
+# a single gateway hiccup fabricates a full sweep of beverage presses that were
+# never made, on a machine whose lifetime counters never moved. Observed on
+# ECAM610.55: ten such blips in seven days, every one lasting exactly one poll.
+TRANSIENT_FAILURE_TOLERANCE = 3
 
 # Config
 CONF_EMAIL = "email"

--- a/custom_components/delonghi_coffeelink/coordinator.py
+++ b/custom_components/delonghi_coffeelink/coordinator.py
@@ -51,6 +51,7 @@ from .const import (
     RECIPE_STORE_SAVE_DELAY,
     RECIPE_STORE_VERSION,
     RESPONSE_PROPERTY_CANDIDATES,
+    TRANSIENT_FAILURE_TOLERANCE,
     normalize_connection_status,
 )
 from .model_profiles import profile_for
@@ -98,6 +99,8 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._device_app_id: int | None = None
         self._integration_app_id = self._default_app_id
         self._last_connect_at: float = 0
+        # Consecutive failed polls currently being ridden out; reset on success.
+        self._consecutive_failures = 0
         self._session_confirmed = False
         self._session_connect_lock = asyncio.Lock()
         self._session_cold_task: asyncio.Task[None] | None = None
@@ -148,6 +151,47 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await super().async_shutdown()
 
     async def _async_update_data(self) -> dict[str, Any]:
+        """Poll the cloud, riding out a short run of transient failures.
+
+        Ayla's endpoints intermittently answer 504/503. The HTTP layer retries
+        those (see ayla_client._request_json); this catches a blip that outlives
+        the retries. Rather than let one bad poll mark the whole device
+        unavailable, keep serving the last good snapshot for up to
+        TRANSIENT_FAILURE_TOLERANCE consecutive failures.
+
+        Why this matters more than it looks: `CoordinatorEntity.available` is
+        just `coordinator.last_update_success`, so one UpdateFailed flips every
+        entity this coordinator owns, and the recovery write is indistinguishable
+        from a real event on entity types whose state IS an event. The logbook
+        duly reports every beverage button as "Pressed", twice, on a machine
+        nobody touched.
+
+        Deliberately NOT silent: each tolerated failure logs a warning, so a real
+        outage is visible from the first poll rather than only after ~2 min. The
+        first refresh is never tolerated - with no previous data there is nothing
+        to serve, and setup must fail honestly with ConfigEntryNotReady.
+        """
+        try:
+            props = await self._fetch_once()
+        except UpdateFailed as err:
+            self._consecutive_failures += 1
+            if (
+                self._consecutive_failures <= TRANSIENT_FAILURE_TOLERANCE
+                and self.data is not None
+            ):
+                _LOGGER.warning(
+                    "Delonghi poll failed (%d/%d tolerated), serving last known "
+                    "data to keep entities available: %s",
+                    self._consecutive_failures,
+                    TRANSIENT_FAILURE_TOLERANCE,
+                    err,
+                )
+                return self.data
+            raise
+        self._consecutive_failures = 0
+        return props
+
+    async def _fetch_once(self) -> dict[str, Any]:
         """Fetch all properties + refresh device meta."""
         try:
             props = await self.client.async_get_properties(self.device.dsn)

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import importlib.util
+import json as jsonlib
 import sys
 import time
 import types
@@ -658,11 +659,18 @@ def test_a_corrupt_blob_never_breaks_the_poll():
 
 
 class _FakeResponse:
-    def __init__(self, payload) -> None:
+    def __init__(self, payload, status: int = 200, content_type: str = "application/json") -> None:
         self._payload = payload
+        self.status = status
+        self.content_type = content_type
 
     async def json(self):
         return self._payload
+
+    async def text(self):
+        if isinstance(self._payload, str):
+            return self._payload
+        return jsonlib.dumps(self._payload)
 
     async def __aenter__(self):
         return self
@@ -672,12 +680,25 @@ class _FakeResponse:
 
 
 class _FakeSession:
-    """aiohttp.ClientSession.get(), enough for async_get_devices."""
+    """aiohttp.ClientSession, enough for the client's read paths.
 
-    def __init__(self, payload) -> None:
+    ``request()`` is the one that matters: every Ayla read goes through
+    ``_request_json``. A canned list of responses lets a test replay a gateway
+    error followed by a good answer.
+    """
+
+    def __init__(self, payload, responses: list | None = None) -> None:
         self._payload = payload
+        self._responses = list(responses or [])
+        self.calls: list[tuple[str, str]] = []
 
     def get(self, url, headers=None):
+        return _FakeResponse(self._payload)
+
+    def request(self, method, url, headers=None, json=None, data=None):
+        self.calls.append((method, url))
+        if self._responses:
+            return self._responses.pop(0)
         return _FakeResponse(self._payload)
 
 
@@ -816,3 +837,116 @@ def test_the_last_connected_sensor_is_registered_on_every_machine():
     assert "entities.append(DelonghiLastConnectedSensor(coord))" in source
     assert 'super().__init__(coord, "last_connected", "mdi:clock-outline")' in source
     assert "self.coordinator.device.connected_at" in source
+
+
+# --- transient cloud failures must not flap every entity --------------------
+#
+# Ayla answers 504/503 with a text/plain body often enough to matter (ten blips
+# in seven days on the reference machine, each exactly one poll long). The cost
+# is out of all proportion to the fault: CoordinatorEntity.available is just
+# coordinator.last_update_success, so one UpdateFailed takes every entity of the
+# device unavailable and the next poll brings them all back - and the logbook
+# renders both edges of a `button` as "Pressed", inventing a full sweep of
+# beverage presses on a machine nobody touched.
+
+class _FlakyClient(_PollingClient):
+    """A polling client whose next N property reads blow up."""
+
+    def __init__(self, failures: int = 0, **kw) -> None:
+        super().__init__(**kw)
+        self.failures = failures
+        self.calls = 0
+
+    async def async_get_properties(self, dsn: str) -> dict:
+        self.calls += 1
+        if self.failures > 0:
+            self.failures -= 1
+            raise RuntimeError("504, message='Attempt to decode JSON with "
+                               "unexpected mimetype: text/plain'")
+        return self.props
+
+
+def _primed(client):
+    """A coordinator that has already completed one successful poll."""
+    coord = _coord("DL-millcore", client=client)
+    coord.data = asyncio.run(coord._async_update_data())
+    assert coord.data is not None
+    return coord
+
+
+def test_a_single_transient_failure_keeps_the_last_good_data():
+    """The measured case: one 504, recovered on the next poll."""
+    client = _FlakyClient(props={"d700_tot_bev_b": {"value": 4638}})
+    coord = _primed(client)
+    good = coord.data
+
+    client.failures = 1
+    assert asyncio.run(coord._async_update_data()) is good  # same object, not a refetch
+    assert coord._consecutive_failures == 1
+
+    coord.data = asyncio.run(coord._async_update_data())
+    assert coord._consecutive_failures == 0
+
+
+def test_a_sustained_outage_is_still_reported():
+    """Tolerance must not become a mute button: the 4th failure gives up."""
+    client = _FlakyClient(props={"d700_tot_bev_b": {"value": 4638}})
+    coord = _primed(client)
+
+    client.failures = 99
+    for _ in range(const.TRANSIENT_FAILURE_TOLERANCE):
+        asyncio.run(coord._async_update_data())
+    with pytest.raises(coordinator.UpdateFailed):
+        asyncio.run(coord._async_update_data())
+
+
+def test_the_tolerance_budget_resets_after_a_success():
+    """Two blips, a good poll, then three more must not trip the limit."""
+    client = _FlakyClient(props={"d700_tot_bev_b": {"value": 4638}})
+    coord = _primed(client)
+
+    client.failures = 2
+    asyncio.run(coord._async_update_data())
+    asyncio.run(coord._async_update_data())
+    coord.data = asyncio.run(coord._async_update_data())   # recovery
+    assert coord._consecutive_failures == 0
+
+    client.failures = const.TRANSIENT_FAILURE_TOLERANCE
+    for _ in range(const.TRANSIENT_FAILURE_TOLERANCE):
+        asyncio.run(coord._async_update_data())            # no raise
+
+
+def test_the_very_first_poll_is_never_tolerated():
+    """With no previous snapshot there is nothing to serve - setup must fail."""
+    client = _FlakyClient(failures=1, props={})
+    coord = _coord("DL-millcore", client=client)
+    assert coord.data is None
+    with pytest.raises(coordinator.UpdateFailed):
+        asyncio.run(coord._async_update_data())
+
+
+def test_a_gateway_error_with_a_text_body_is_retried_not_raised():
+    """The exact shape that used to escape as an unretryable ContentTypeError.
+
+    Ayla answers 504 with a ``text/plain`` body. The old async_get_devices /
+    async_get_properties called ``resp.json()`` directly with no status check, so
+    aiohttp raised ContentTypeError and the retry loop - which existed, and was
+    correct - never saw it because those paths bypassed it entirely.
+    """
+    good = [{"device": {"dsn": "AC000W019023280", "product_name": "x",
+                        "oem_model": "DL-millcore", "model": "AY008ESP1",
+                        "sw_version": "ADA 1.5.3", "lan_ip": "10.0.0.1",
+                        "connection_status": "Online",
+                        "connected_at": "2026-08-12T04:01:46Z"}}]
+    session = _FakeSession(good, responses=[
+        _FakeResponse("504 Gateway Time-out", status=504, content_type="text/plain"),
+        _FakeResponse(good),
+    ])
+    client = ac.DelonghiAylaClient(session, "user@example.com", "secret")
+    client._access_token = "token"
+    client._expires_at = time.time() + 3600
+
+    devices = asyncio.run(client.async_get_devices())
+
+    assert [d.dsn for d in devices] == ["AC000W019023280"]
+    assert len(session.calls) == 2, "the 504 must have been retried, not surfaced"


### PR DESCRIPTION
## The symptom

The household opened Home Assistant to find **every beverage the machine can make listed as "Pressed"** — twice in one morning — on a machine nobody had touched. Espresso, Cortado, Brew Over Ice, Tea, the lot.

Nothing was brewed. 23 of 25 buttons still read `unknown` (a `ButtonEntity`'s state *is* its last-press timestamp, and only `async_press` writes it), and five of the "pressed" drinks have a **lifetime counter of 0** — the machine has never made one, in ~4900 drinks.

## The mechanism

`CoordinatorEntity.available` is just `coordinator.last_update_success`. So **one** `UpdateFailed` takes every non-numeric entity of the device to `unavailable`, and the next successful poll writes them all back. The logbook renders **both** edges of a `button` as "Pressed" — so a single hiccup fabricates ~60 rows, ~50 of them fake brews.

The numeric counters flap too, but the logbook drops sensors carrying a unit — which is precisely why the artifact looks button-specific, and therefore believable.

## The cause

```
ERROR [custom_components.delonghi_coffeelink.coordinator] Error fetching ... data:
Error fetching Delonghi data: 504,
message='Attempt to decode JSON with unexpected mimetype: text/plain',
url='https://ads-eu.aylanetworks.com/apiv1/dsns/<dsn>/properties.json'
```

**Ten occurrences in seven days** on an ECAM610.55 (9× `504`, 1× `503`; seven on `/properties.json`, three on `/devices.json`), each matching a `machine_status` dropout to the second, each lasting exactly one poll interval.

🔴 **The retry machinery already existed and was already correct.** `_request_json` reads `resp.text()` *before* parsing and retries `{429, 502, 503, 504}`. But `async_get_properties` and `async_get_devices` each did a bare `session.get()` + `await resp.json()` with **no status check at all**, so they never reached it.

Its docstring said *"HTTP request with transient retry (Eletta session paths only)"* — a stale comment describing a limitation nobody revisited after the polling code was written.

## The change

1. **`ayla_client.py`** — route both polling reads through `_request_json`. Fixes the cause.
2. **`const.py` + `coordinator.py`** — `TRANSIENT_FAILURE_TOLERANCE = 3` behind it: serve the last good snapshot for up to three consecutive failures (~2 min) before entities go unavailable. **Never silent** — each tolerated poll logs a warning, so a genuine outage is visible from the first failure, not only after two minutes. The first refresh is never tolerated (nothing to serve → `ConfigEntryNotReady` as before).

The two layers log differently on purpose, so a real blip tells you which one caught it: `"Ayla transient HTTP 504 … retry 1/2"` vs `"Delonghi poll failed (1/3 tolerated)"`.

⛔ **`async_set_property_value` is deliberately NOT retried.** It is the command channel (`data_request`) — a blind POST retry there could brew two coffees. It already checks `resp.status` before parsing, so it raises a clean `CloudError` rather than a `ContentTypeError`.

## Tests

5 new cases, added to `test_coordinator_session.py` — the module whose docstring says it owns the coordinator stubs and that new coordinator cases belong there.

- `test_a_gateway_error_with_a_text_body_is_retried_not_raised` replays the exact 504 + `text/plain` shape and asserts the call was retried.
- three cover the tolerance window (single blip tolerated; 4th consecutive gives up; budget resets after a success)
- one pins that the very first poll is never tolerated

**4 of the 5 fail without the source change**, verified by stashing only `custom_components/`. `186 passed`, `ruff check` clean.

Two pre-existing tests needed their `_FakeSession` fixture taught `request()` — it only modelled the old `get()` call shape.

## Deployed

Running on the reference machine (ECAM610.55, `DL-millcore`, ADA 1.5.3) since 2026-09-01. Verified by effect: `[get_properties]` / `[get_devices]` op tags — which exist only inside `_request_json` — now appear in the HTTP debug log every 30 s; 58/58 entities available; buttons untouched.

⚠️ Stated honestly: **the tolerance path has not yet met a real 504 in production** — I could find no safe way to inject one. The HTTP-layer fix is what the deployment exercises; the tolerance window is covered by the unit tests above.
