### PR TITLE
feat: read the machine's own beverage catalogue, and stop discarding saved recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,10 +160,9 @@ cloud accepted with `200 OK` and never delivered.
 ### Changed
 - **BREAKING for statistics** - `Water Total Quantity` and `Water Filter
   Quantity` now report **litres** instead of a unitless count. De'Longhi
-  machines publish these counters in millilitres (independently confirmed by
-  De'Longhi's own statistics sheet, by `sk7n4k3d/delonghi-ha` which applies
-  `scale=0.001` to the same datapoints, and by `PyDeLonghiAPI` which derives
-  lifetime litres as `d553 / 1000`), and Home Assistant's water device class
+  machines publish these counters in millilitres (confirmed against De'Longhi's
+  own statistics sheet, which is denominated in litres), and Home Assistant's
+  water device class
   works in litres. Existing installations have long-term statistics recorded
   without a unit, so Home Assistant will raise a "units changed" repair for
   these two entities; accepting it keeps history consistent with the new unit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+The machine has been publishing its own beverage catalogue all along, in the
+properties this integration already polls every 30 seconds. Nothing here creates
+or removes an entity yet - it reads what is there, proves it intact, and stops
+the integration throwing away data it needs.
+
+### Added
+- **The machine's own beverage catalogue is now parsed** (`catalog.py`). Every
+  recipe datapoint is a self-describing blob, `d0 <len> <family> [<profile>]
+  <bevid> <TLV...> <crc16>`, carrying the same CRC16 AUG-CCITT the command
+  builder already uses - so it can be *proved* intact before anything is derived
+  from it. Measured on the reference PrimaDonna Soul (312 properties): 194 blobs,
+  163 complete, **163/163 checksums valid**, and one TLV rule (tags `0x01`,
+  `0x09`, `0x0f` are 16-bit, everything else 8-bit) consumes **140/140** recipe
+  payloads with zero leftover bytes.
+
+  What the machine turns out to publish: which drinks it *actually* offers and in
+  what order, per profile (18 on the reference machine - the integration ships 21
+  buttons for it, so three are fiction); the current quantity of every parameter
+  of every drink on every profile; the **editable min/default/max ranges** from
+  the factory descriptors (hot water 20/250/420 ml, hot milk 50/360/1080); the
+  six saved-recipe slots and the bean-system drink, none of which the hardcoded
+  beverage list has ever had; and the user-entered names.
+
+  It is read-only for now and costs no new request - roughly 4 ms of parsing,
+  behind a fingerprint so it only re-runs when a recipe actually changes.
+
+### Fixed
+- **A drink you saved on the machine could never be learned.** `learnable_
+  beverage_id` accepted only the 21 hardcoded ids, so pressing "Perso 1" (ids
+  `0xe6`-`0xeb`) or a bean-system drink (`0xc8`) in the official app had its
+  captured frame **discarded in silence** - and on a learn-and-replay model that
+  frame is the only way the integration could ever reproduce that drink. The gate
+  now also accepts the ids the machine itself declares. The checksum rule is
+  unchanged: a corrupt frame is still never learned.
+- **The recipe dump missed exactly the recipes worth dumping.** It selected
+  properties by the substring `_rec_`, which on the reference machine caught 137
+  datapoints and skipped all 30 saved-recipe blobs, all 5 bean-system recipes and
+  `d022_beansystem_1`. It now selects by blob family, so the diagnostic surfaces
+  all 194 - and it no longer depends on property names, which differ per model
+  (`d039_1_rec_espresso` on the Soul, `d059_rec_1_espresso` on the Eletta, with
+  the numbers shifted by 20 for the same drink).
+
+### Security
+- **The recipe dump no longer publishes the machine's serial number.** The
+  machine wraps its serial (`d270`), its settings PIN (`d280`), the monitor blob
+  and the command-response channel in the *same* `0xd0` envelope as its recipes,
+  so selecting on that prefix alone would have put a serial in every bug report -
+  and the README asks users to paste this block into public GitHub issues. Only
+  the six catalogue families are rendered now, and the user-entered text of the
+  three name families (profile names are first names) is replaced by a byte
+  count. The old `_rec_` filter never reached any of them.
+
+### Notes
+- Nothing derived here is asserted beyond what the bytes support. A blob that
+  fails any gate is *unreadable*, never *absent*; a TLV walk with a leftover byte
+  is refused whole rather than half-parsed; `off_default` is `None` - not `False`
+  - wherever the factory descriptor is truncated, and cross-profile disagreement
+  is reported separately as the weaker signal it is.
+- `tests/fixtures/soul_properties.json` is a real 312-property dump, anonymised:
+  the serial, the Wi-Fi MAC (three plain integers - a scan that only reads the
+  base64 strings walks straight past it) and every user-entered name were
+  overwritten, with checksums recomputed. `fixtures/anonymise_dump.py` reproduces
+  it and a test fails the day the fixture is refreshed without re-anonymising.
+
 ## [0.3.19] - 2026-08-22
 
 Everything here comes from one field diagnosis on the reference PrimaDonna Soul:

--- a/custom_components/delonghi_coffeelink/catalog.py
+++ b/custom_components/delonghi_coffeelink/catalog.py
@@ -1,0 +1,527 @@
+"""Read the machine's own beverage catalogue out of its Ayla datapoints.
+
+The machine already tells us everything a beverage catalogue needs; the
+integration just never read it. Every recipe-bearing datapoint is a
+self-describing binary blob::
+
+    d0 <len> <family 2B> [<profile 1B>] <bevid 1B> <TLV params...> <crc16>
+
+``len`` is the frame size minus the start byte, and the CRC is the same CRC16
+AUG-CCITT the command builder already uses, so a blob can be *proved* intact
+before anything is derived from it. The reference PrimaDonna Soul (312
+properties) publishes 194 such blobs in ten families; these six carry the
+catalogue, and are the only ones this module reads:
+
+===========  ====  ==============================================================
+family       n     meaning
+===========  ====  ==============================================================
+``b0 f0``    28    factory descriptor - the capability schema (min/default/max)
+``a6 f0``    140   per-profile instance - the current value of each parameter
+``a8 f0``    5     the machine's own ordered menu, one list per profile
+``a4 f0``    2     profile names (UTF-16BE, user-entered)
+``aa f0``    2     custom-recipe slot names
+``ba f0``    7     bean-system names
+===========  ====  ==============================================================
+
+The other four are the serial number (``a1 0f``), the machine settings including
+the PIN (``95 0f``), the monitor blob (``75 0f``) and the command-response
+channel (``a9 f0``). They are deliberately out of scope here, and out of the
+diagnostic dump too - see ``command_builder.recipe_dump_lines``.
+
+Two rules make the whole thing parseable without per-beverage special cases:
+
+* **TLV**: tags ``0x01``, ``0x09`` and ``0x0f`` carry a 16-bit big-endian value,
+  every other tag carries 8 bits. That single rule consumes all 140 ``a6f0``
+  payloads with zero leftover bytes. In a ``b0f0`` descriptor the same tags
+  carry a *triple* (min, default, max) instead of one value.
+* **Parse by family, never by property name.** The Soul writes
+  ``d039_1_rec_espresso`` and the Eletta ``d059_rec_1_espresso``, with the
+  numbers shifted by 20 for the same drink; the blob header is identical on
+  both.
+
+Everything here is pure: no Home Assistant, no I/O, no network. Callers hand it
+the property dict the coordinator already polls.
+
+Deliberate refusals, because a beverage button that lies is worse than one that
+is missing:
+
+* A blob that fails any gate (prefix, declared length, CRC) is *unreadable*,
+  never *absent* - it never removes a beverage from the catalogue.
+* A TLV walk that leaves a trailing byte returns ``None`` rather than a partial
+  parse, so a synthesized command can never be built from a half-understood
+  payload.
+* ``off_default`` is ``None``, not ``False``, when the factory descriptor is
+  truncated or missing. Cross-profile disagreement is reported separately as
+  ``profiles_differ`` - it is a weaker signal and must not be read as "the user
+  changed this".
+* ``on_menu`` is ``None`` for anything the menu blob does not enumerate (custom
+  slots, bean-system), so it can never be used as an existence test against the
+  very entries discovery exists to find.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+from collections.abc import Iterator
+from typing import Any
+
+from .command_builder import crc16_aug_ccitt
+from .const import (
+    BLOB_FAMILY_BEAN_NAMES,
+    BLOB_FAMILY_CUSTOM_NAMES,
+    BLOB_FAMILY_DESCRIPTOR,
+    BLOB_FAMILY_MENU,
+    BLOB_FAMILY_PROFILE_NAMES,
+    BLOB_FAMILY_PROFILE_RECIPE,
+    CMD_RESPONSE_PREFIX,
+)
+
+# The family bytes live in const.py because the diagnostic dump in
+# command_builder needs them too, and importing this module from there would
+# close an import cycle.
+BLOB_PREFIX = CMD_RESPONSE_PREFIX
+
+FAMILY_DESCRIPTOR = BLOB_FAMILY_DESCRIPTOR
+FAMILY_PROFILE_RECIPE = BLOB_FAMILY_PROFILE_RECIPE
+FAMILY_MENU = BLOB_FAMILY_MENU
+FAMILY_PROFILE_NAMES = BLOB_FAMILY_PROFILE_NAMES
+FAMILY_CUSTOM_NAMES = BLOB_FAMILY_CUSTOM_NAMES
+FAMILY_BEAN_NAMES = BLOB_FAMILY_BEAN_NAMES
+
+FAMILY_LABELS = {
+    FAMILY_DESCRIPTOR: "factory_descriptor",
+    FAMILY_PROFILE_RECIPE: "profile_recipe",
+    FAMILY_MENU: "menu_order",
+    FAMILY_PROFILE_NAMES: "profile_names",
+    FAMILY_CUSTOM_NAMES: "custom_names",
+    FAMILY_BEAN_NAMES: "bean_names",
+}
+
+#: TLV tags whose value is 16-bit big-endian; every other tag is 8-bit.
+WIDE_TAGS = frozenset({0x01, 0x09, 0x0F})
+
+#: Beverage-id ranges that are not one of the built-in drinks.
+CUSTOM_SLOT_IDS = frozenset(range(0xE6, 0xEC))
+BEAN_SYSTEM_IDS = frozenset(range(0xC8, 0xCE))
+
+#: An unprogrammed custom slot: no coffee quantity and the 0xff intensity marker.
+_EMPTY_SLOT_INTENSITY = 0xFF
+
+# Tag meanings pinned by value range against the reference machine. Only the
+# five below are confirmed; the rest are carried through unnamed rather than
+# guessed at.
+TAG_COFFEE_ML = 0x01
+TAG_MILK = 0x09
+TAG_WATER_ML = 0x0F
+TAG_TEMPERATURE = 0x1B
+TAG_CUP_COUNT = 0x1E
+TAG_INTENSITY = 0x02
+
+#: Smallest payload each family can carry and still be indexable: the header
+#: bytes that precede the parameters (bevid, or profile + bevid, or the two
+#: slot-index bytes of a text blob).
+_MIN_PAYLOAD = {
+    FAMILY_DESCRIPTOR: 1,
+    FAMILY_PROFILE_RECIPE: 2,
+    FAMILY_MENU: 2,
+    FAMILY_PROFILE_NAMES: 2,
+    FAMILY_CUSTOM_NAMES: 2,
+    FAMILY_BEAN_NAMES: 2,
+}
+
+TAG_NAMES = {
+    TAG_COFFEE_ML: "coffee_ml",
+    TAG_MILK: "milk",
+    TAG_WATER_ML: "water_ml",
+    TAG_TEMPERATURE: "temperature",
+    TAG_CUP_COUNT: "cup_count",
+    TAG_INTENSITY: "intensity",
+}
+
+
+def _b64_bytes(value: Any) -> bytes | None:
+    """Decode a datapoint value to bytes, tolerating a truncated dump.
+
+    Ayla string datapoints arrive with stray whitespace, and a dump taken with a
+    width limit can cut a base64 value mid-quantum - which is not valid base64 at
+    all. Keeping the largest 4-character multiple recovers every complete byte
+    and loses only the partial one, so a truncated blob is still classifiable
+    instead of vanishing.
+    """
+    if not isinstance(value, str):
+        return None
+    clean = "".join(value.split())
+    if not clean:
+        return None
+    try:
+        return base64.b64decode(clean[: len(clean) // 4 * 4], validate=True)
+    except (ValueError, binascii.Error):
+        return None
+
+
+def blob_family(value: Any) -> bytes | None:
+    """The family bytes of a machine blob, read without decoding all of it.
+
+    Only the first 8 base64 characters are decoded - 6 bytes, enough for the
+    prefix and the family - so a caller can tell what a datapoint is at a
+    fraction of the cost of parsing it. Returns ``None`` for anything that is
+    not a ``0xd0`` blob.
+    """
+    if not isinstance(value, str):
+        return None
+    head = "".join(value.split())[:8]
+    if len(head) < 8:
+        return None
+    try:
+        raw = base64.b64decode(head, validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    return bytes(raw[2:4]) if raw[0] == BLOB_PREFIX else None
+
+
+def catalog_fingerprint(props: dict) -> tuple:
+    """A change-detection key over the catalogue datapoints, and only those.
+
+    Cheap enough to run on every poll, and deliberately narrow. Two things go
+    wrong if it is widened to "any value that looks like a blob":
+
+    * ``d302_monitor`` and ``data_response`` wear the same envelope and carry a
+      fresh timestamp on almost every poll, so the key would change constantly
+      and the catalogue would be re-parsed for nothing;
+    * whitespace. Ayla wraps string datapoints in it, so a key that compares raw
+      values while the parser strips them can disagree about what changed - and
+      a change-detector that cannot see a change is how a cache freezes without
+      anyone noticing.
+    """
+    return tuple(
+        (name, "".join(value.split()))
+        for name in sorted(props)
+        for prop in (props.get(name),)
+        for value in (prop.get("value") if isinstance(prop, dict) else prop,)
+        if blob_family(value) in FAMILY_LABELS
+    )
+
+
+def decode_blob(value: Any) -> dict | None:
+    """Classify one datapoint value as a machine blob, or ``None`` if it is not.
+
+    Returns a dict describing what could be established, never raising. Three
+    gates, in order: the ``0xd0`` prefix, the declared length, and the CRC.
+
+    The length gate is ``declared <= len(raw)``, not ``==``: the machine appends
+    a 4-byte timestamp to some datapoints (``data_response``, ``d302_monitor``),
+    and a strict equality would misgrade those live channels as truncated.
+    """
+    raw = _b64_bytes(value)
+    if raw is None or len(raw) < 6 or raw[0] != BLOB_PREFIX:
+        return None
+    declared = raw[1] + 1
+    family = bytes(raw[2:4])
+    out: dict[str, Any] = {
+        "raw": raw,
+        "family": family,
+        "family_label": FAMILY_LABELS.get(family, family.hex(" ")),
+        "declared_length": declared,
+        "length": len(raw),
+    }
+    if declared > len(raw):
+        out.update(truncated=True, crc_valid=False, frame=None, payload=None)
+        return out
+    frame = raw[:declared]
+    crc_valid = crc16_aug_ccitt(frame[:-2]) == int.from_bytes(frame[-2:], "big")
+    out.update(
+        truncated=False,
+        crc_valid=crc_valid,
+        frame=frame,
+        trailer=raw[declared:],
+        payload=frame[4:-2],
+    )
+    return out
+
+
+def parse_tlv(payload: bytes) -> dict[int, int] | None:
+    """Parse a TLV parameter payload, or ``None`` if it does not consume exactly.
+
+    A trailing byte means the grammar does not fit this payload, and a partial
+    parse is exactly the input that would build a wrong brew command, so the
+    whole walk is refused rather than truncated.
+    """
+    out: dict[int, int] = {}
+    i = 0
+    end = len(payload)
+    while i < end:
+        tag = payload[i]
+        width = 2 if tag in WIDE_TAGS else 1
+        if i + 1 + width > end:
+            return None
+        out[tag] = int.from_bytes(payload[i + 1 : i + 1 + width], "big")
+        i += 1 + width
+    return out
+
+
+def parse_triples(payload: bytes) -> dict[int, tuple[int, int, int]] | None:
+    """Parse a factory descriptor payload into ``tag -> (min, default, max)``.
+
+    Same tag widths as :func:`parse_tlv`, three values per tag instead of one.
+    Returns ``None`` on any leftover byte, for the same reason.
+    """
+    out: dict[int, tuple[int, int, int]] = {}
+    i = 0
+    end = len(payload)
+    while i < end:
+        tag = payload[i]
+        width = 2 if tag in WIDE_TAGS else 1
+        if i + 1 + 3 * width > end:
+            return None
+        values = tuple(
+            int.from_bytes(payload[i + 1 + n * width : i + 1 + (n + 1) * width], "big")
+            for n in range(3)
+        )
+        out[tag] = values  # type: ignore[assignment]
+        i += 1 + 3 * width
+    return out
+
+
+def decode_text(payload: bytes) -> str | None:
+    """Decode the first UTF-16BE name in a text blob payload.
+
+    Names live in NUL-padded fixed-width slots, but the slot width varies with
+    the blob and a name shorter than the slot leaves the following slots
+    misaligned - so only the first name is read. Returns ``None`` when the slot
+    is empty or the bytes do not decode.
+    """
+    try:
+        text = payload.decode("utf-16-be", errors="ignore")
+    except (UnicodeDecodeError, ValueError):
+        return None
+    name = text.split("\x00", 1)[0].strip()
+    return name or None
+
+
+def iter_blobs(props: dict) -> Iterator[tuple[str, dict]]:
+    """Yield ``(property_name, decoded_blob)`` for every machine blob in ``props``.
+
+    Property names are carried through as labels only - the blob header, never
+    the name, decides what a datapoint is.
+    """
+    for name in sorted(props):
+        prop = props.get(name)
+        value = prop.get("value") if isinstance(prop, dict) else prop
+        blob = decode_blob(value)
+        if blob is not None:
+            yield name, blob
+
+
+def _new_entry(bev_id: int) -> dict:
+    if bev_id in CUSTOM_SLOT_IDS:
+        kind = "custom"
+    elif bev_id in BEAN_SYSTEM_IDS:
+        kind = "bean_system"
+    else:
+        kind = "builtin"
+    return {
+        "id": bev_id,
+        "kind": kind,
+        "declared": False,
+        "descriptor_truncated": False,
+        "ranges": {},
+        "profiles": {},
+        "on_menu": None,
+        "menu_position": {},
+        "defined": None,
+        "profiles_differ": False,
+        "off_default": None,
+        "source_properties": [],
+    }
+
+
+def _slot_is_defined(params: dict[int, int]) -> bool:
+    """True when a custom slot has actually been programmed on the machine.
+
+    An untouched slot reads back as coffee quantity 0 with the 0xff intensity
+    marker - the machine's own "not defined yet" state.
+    """
+    unset = params.get(TAG_INTENSITY) == _EMPTY_SLOT_INTENSITY
+    if unset and not params.get(TAG_COFFEE_ML):
+        return False
+    return any(params.get(tag) for tag in (TAG_COFFEE_ML, TAG_MILK, TAG_WATER_ML))
+
+
+def build_catalog(props: dict) -> dict:
+    """Build the machine's beverage catalogue from its polled properties.
+
+    Pure function of ``props``: no I/O, no network, no new protocol traffic. The
+    caller decides what to do with it; nothing here creates or removes entities.
+    """
+    beverages: dict[int, dict] = {}
+    menu: dict[int, list[int]] = {}
+    names: dict[str, dict[int, str]] = {"profiles": {}, "custom": {}, "beans": {}}
+    stats = {
+        "blobs": 0,
+        "crc_ok": 0,
+        "crc_failed": 0,
+        "truncated": 0,
+        "unparsed_payloads": 0,
+        "short_payloads": 0,
+        "families": {},
+    }
+
+    def entry(bev_id: int) -> dict:
+        return beverages.setdefault(bev_id, _new_entry(bev_id))
+
+    for name, blob in iter_blobs(props):
+        stats["blobs"] += 1
+        label = blob["family_label"]
+        stats["families"][label] = stats["families"].get(label, 0) + 1
+        if blob["truncated"]:
+            stats["truncated"] += 1
+            # A truncated descriptor still proves the drink exists; only its
+            # ranges are unknown.
+            if blob["family"] == FAMILY_DESCRIPTOR and blob["length"] >= 5:
+                item = entry(blob["raw"][4])
+                item["declared"] = True
+                item["descriptor_truncated"] = True
+                item["source_properties"].append(name)
+            continue
+        if not blob["crc_valid"]:
+            stats["crc_failed"] += 1
+            continue
+        stats["crc_ok"] += 1
+        family, payload = blob["family"], blob["payload"]
+        # A frame can declare a length that leaves no header room at all. It has
+        # already passed the CRC by then, so the shape has to be checked before
+        # any byte is indexed - a short blob is one more thing that is
+        # unreadable, never something that removes a beverage.
+        if len(payload) < _MIN_PAYLOAD.get(family, 0):
+            stats["short_payloads"] += 1
+            continue
+
+        if family == FAMILY_DESCRIPTOR:
+            bev_id, body = payload[0], payload[1:]
+            item = entry(bev_id)
+            item["declared"] = True
+            item["source_properties"].append(name)
+            triples = parse_triples(body)
+            if triples is None:
+                stats["unparsed_payloads"] += 1
+            else:
+                item["ranges"] = triples
+        elif family == FAMILY_PROFILE_RECIPE:
+            profile, bev_id, body = payload[0], payload[1], payload[2:]
+            item = entry(bev_id)
+            item["source_properties"].append(name)
+            params = parse_tlv(body)
+            if params is None:
+                stats["unparsed_payloads"] += 1
+            else:
+                item["profiles"][profile] = params
+        elif family == FAMILY_MENU:
+            profile = payload[0]
+            menu[profile] = list(payload[2:])
+        elif family in (FAMILY_PROFILE_NAMES, FAMILY_CUSTOM_NAMES, FAMILY_BEAN_NAMES):
+            bucket = {
+                FAMILY_PROFILE_NAMES: "profiles",
+                FAMILY_CUSTOM_NAMES: "custom",
+                FAMILY_BEAN_NAMES: "beans",
+            }[family]
+            # payload = <first slot> <last slot> <UTF-16BE text...>; the text
+            # starts at 2, and starting at 1 shifts every character by a byte.
+            text = decode_text(payload[2:])
+            if text:
+                names[bucket][payload[0]] = text
+
+    _apply_menu(beverages, menu)
+    for item in beverages.values():
+        _finalize(item)
+
+    return {
+        "source": "machine" if beverages else "empty",
+        "beverages": beverages,
+        "menu": menu,
+        "names": names,
+        "stats": stats,
+    }
+
+
+def _apply_menu(beverages: dict[int, dict], menu: dict[int, list[int]]) -> None:
+    """Mark which built-in drinks the machine actually lists in its own menu.
+
+    ``on_menu`` stays ``None`` for custom slots and the bean system: the menu
+    blob enumerates neither, so treating absence as "does not exist" would
+    suppress exactly the entries discovery is for.
+    """
+    if not menu:
+        return
+    listed = {bev_id for ids in menu.values() for bev_id in ids}
+    for profile, ids in menu.items():
+        for position, bev_id in enumerate(ids):
+            item = beverages.setdefault(bev_id, _new_entry(bev_id))
+            item["menu_position"][profile] = position
+    for bev_id, item in beverages.items():
+        if item["kind"] == "builtin":
+            item["on_menu"] = bev_id in listed
+
+
+def _finalize(item: dict) -> None:
+    """Derive the customisation signals once all blobs have been folded in."""
+    profiles = item["profiles"]
+    if item["kind"] == "custom" and profiles:
+        item["defined"] = any(_slot_is_defined(params) for params in profiles.values())
+
+    if len(profiles) > 1:
+        tags = {tag for params in profiles.values() for tag in params}
+        item["profiles_differ"] = any(
+            len({params.get(tag) for params in profiles.values()}) > 1 for tag in tags
+        )
+
+    # Only a readable factory descriptor can say whether a value was changed.
+    # Without one the answer is unknown, and unknown must not read as "no".
+    if item["ranges"] and profiles:
+        off_default: dict[int, bool] = {}
+        for tag, triple in item["ranges"].items():
+            default = triple[1]
+            values = [params[tag] for params in profiles.values() if tag in params]
+            if values:
+                off_default[tag] = any(value != default for value in values)
+        item["off_default"] = off_default
+
+
+def catalog_beverage_ids(catalog: dict | None) -> set[int]:
+    """Every beverage id the machine declared, whatever its kind.
+
+    Used to widen the learn gate: a frame the official app sent for a drink the
+    machine declares is worth keeping even when the integration has no built-in
+    entry for it.
+    """
+    if not catalog:
+        return set()
+    beverages = catalog.get("beverages", {})
+    return {bev_id for bev_id, item in beverages.items() if item["declared"]}
+
+
+def catalog_summary(catalog: dict | None) -> str:
+    """One-line summary for the diagnostic log."""
+    if not catalog or catalog.get("source") == "empty":
+        return "no machine catalogue (no readable recipe blobs)"
+    beverages = catalog["beverages"]
+    stats = catalog["stats"]
+    on_menu = sum(1 for item in beverages.values() if item["on_menu"] is True)
+    off_menu = sum(1 for item in beverages.values() if item["on_menu"] is False)
+    custom = sum(1 for item in beverages.values() if item["kind"] == "custom")
+    defined = sum(1 for item in beverages.values() if item["defined"] is True)
+    with_ranges = sum(1 for item in beverages.values() if item["ranges"])
+    # "0 on the machine menu" and "the machine published no menu" are different
+    # statements, and only one of them is true when no menu blob was readable.
+    menu_part = (
+        f"{on_menu} on the machine menu, {off_menu} declared but off-menu"
+        if catalog["menu"]
+        else "menu not published"
+    )
+    return (
+        f"{len(beverages)} beverage ids ({menu_part}, "
+        f"{custom} custom slots of which {defined} programmed), {with_ranges} with "
+        f"factory min/default/max ranges, {len(catalog['menu'])} profile menus | blobs="
+        f"{stats['blobs']} crc_ok={stats['crc_ok']} crc_failed={stats['crc_failed']} "
+        f"truncated={stats['truncated']} unparsed={stats['unparsed_payloads']} "
+        f"short={stats['short_payloads']}"
+    )

--- a/custom_components/delonghi_coffeelink/command_builder.py
+++ b/custom_components/delonghi_coffeelink/command_builder.py
@@ -16,10 +16,12 @@ from .const import (
     CRC_INIT,
     CRC_POLY,
     DEFAULT_RECIPE_PARAMS,
+    DUMPABLE_BLOB_FAMILIES,
     ELETTA_RECIPE_TRAILER,
     POWER_SESSION_REFRESH_PARAMS,
     POWER_STANDBY_PARAMS,
     POWER_WAKE_PARAMS,
+    TEXT_BLOB_FAMILIES,
 )
 
 _BEV_NAMES = {bev_id: display for bev_id, _key, display, _icon in BEVERAGES}
@@ -146,22 +148,79 @@ def deserialize_learned_frames(
     return _section("start"), _section("stop"), wake
 
 
+def _dumpable_blob(value: object) -> bytes | None:
+    """Decoded bytes of a *recipe-bearing* machine blob, else ``None``.
+
+    Two filters, and the second one matters as much as the first. The ``0xd0``
+    prefix alone is far too wide: the machine uses the same envelope for its
+    serial number (``d270``, family ``a10f``), its settings PIN (``d280``,
+    family ``950f``), the monitor blob and the command-response channel. This
+    dump is the block the README tells people to paste into a public GitHub
+    issue, so only the six families the catalogue actually understands are
+    rendered - see ``catalog.FAMILY_LABELS``.
+
+    Tolerates a dump-truncated base64 value (not a multiple of 4 characters) by
+    keeping the largest complete quantum, so a cut blob is still recognised
+    instead of silently dropping out of the diagnostic.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return None
+    clean = "".join(value.split())
+    try:
+        raw = base64.b64decode(clean[: len(clean) // 4 * 4], validate=True)
+    except (ValueError, binascii.Error):
+        return None
+    if len(raw) < 4 or raw[0] != CMD_RESPONSE_PREFIX:
+        return None
+    return raw if bytes(raw[2:4]) in DUMPABLE_BLOB_FAMILIES else None
+
+
+def _render_blob(name: str, raw: bytes) -> str:
+    """One dump line for a blob, with any user-entered text redacted.
+
+    The three name families carry text the household typed in - profile names
+    are first names on a real machine. Their structure is worth dumping (header,
+    slot indices, length); their content is not, and it is never needed to
+    understand a recipe.
+    """
+    family = bytes(raw[2:4])
+    if family in TEXT_BLOB_FAMILIES:
+        header, text = raw[:6], raw[6:]
+        return f"{name} [family {family.hex()}] = {header.hex(' ')} <{len(text)} bytes of name redacted>"
+    return f"{name} [family {family.hex()}] = {raw.hex(' ')}"
+
+
 def recipe_dump_lines(props: dict) -> list[str]:
     """Render the machine's stored recipe datapoints for a read-only diagnostic.
 
-    Returns ``name = <hex>`` lines for every property whose name contains
-    ``_rec_`` (the per-beverage recipe definitions the machine stores, e.g.
-    ``d059_rec_1_espresso``) plus the active-profile indicator. Base64 blobs are
-    decoded to hex; other values are shown as-is. Sends nothing to the machine -
-    used to confirm whether a stored recipe maps to the beverage command's
-    variable recipe block (the path to drop the "teach from the app" step).
+    Selection is by *blob family*, not by property name. The name-based filter
+    this replaced (``"_rec_" in name``) missed every custom and bean-system
+    recipe - on the reference PrimaDonna Soul it selected 132 of the 168
+    recipe-bearing datapoints (plus the 5 priority lists), dropping the 30
+    ``cstm_recipe`` blobs, the 5 ``bs_recipe`` blobs and ``d022_beansystem_1``,
+    which are precisely the entries a catalogue discovery exists to find. Names
+    are also model-specific (Soul ``d039_1_rec_espresso`` vs Eletta
+    ``d059_rec_1_espresso``, numbers shifted by 20 for the same drink) while the
+    blob header is identical on both.
+
+    What is dumped: the six recipe-bearing families, with the user-entered text
+    of the three name families redacted to a byte count. What is deliberately
+    NOT dumped, even though it wears the same ``0xd0`` envelope: the serial
+    number, the settings PIN, the monitor blob and the response channel. The
+    legacy ``_rec_`` names and the active-profile indicator are still rendered
+    as-is, for continuity and for any model whose recipes are not blob-shaped.
+    Sends nothing to the machine.
     """
     lines: list[str] = []
     for name in sorted(props):
-        if "_rec_" not in name and name != "d286_mach_sett_profile":
-            continue
         prop = props.get(name)
         value = prop.get("value") if isinstance(prop, dict) else prop
+        raw = _dumpable_blob(value)
+        if raw is None and "_rec_" not in name and name != "d286_mach_sett_profile":
+            continue
+        if raw is not None:
+            lines.append(_render_blob(name, raw))
+            continue
         if isinstance(value, str) and value.strip():
             try:
                 rendered = base64.b64decode("".join(value.split()), validate=True).hex(" ")
@@ -355,12 +414,19 @@ def app_id_from_signature(signature: bytes | None) -> int | None:
     return int.from_bytes(signature, "big", signed=True)
 
 
-def learnable_beverage_id(decoded: dict) -> int | None:
+def learnable_beverage_id(decoded: dict, known_ids: Iterable[int] | None = None) -> int | None:
     """Beverage id to learn from a captured app frame, or ``None`` to skip it.
 
     A frame is worth learning when it is a beverage command whose CRC checks out
-    and whose beverage id is one this integration exposes - nothing else. The
-    frame *dialect* is deliberately NOT part of the decision: on a
+    and whose beverage id is one the *machine* has, not merely one this
+    integration hardcodes. ``known_ids`` widens the gate with the ids discovered
+    from the machine's own datapoints (see ``catalog.catalog_beverage_ids``):
+    without it, a user who brews a saved recipe such as "Perso 1" (ids
+    ``0xe6``-``0xeb``) or a bean-system drink (``0xc8``) from the official app
+    has the captured frame silently discarded, and the integration can then
+    never reproduce that drink.
+
+    The frame *dialect* is deliberately NOT part of the decision: on a
     ``learns_from_app`` model every command the app sends is by definition the
     dialect that machine speaks, and the previous `style == "eletta"` gate
     silently dropped every beverage whose recipe happened not to end with the
@@ -379,7 +445,9 @@ def learnable_beverage_id(decoded: dict) -> int | None:
         bev_id = int(decoded.get("beverage_id", ""), 16)
     except (ValueError, TypeError):
         return None
-    return bev_id if bev_id in _BEV_NAMES else None
+    if bev_id in _BEV_NAMES:
+        return bev_id
+    return bev_id if known_ids is not None and bev_id in set(known_ids) else None
 
 
 def is_wake_power_frame(decoded: dict) -> bool:

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -60,6 +60,35 @@ CMD_RESPONSE_PREFIX = 0xd0  # Machine -> app
 CMD_LENGTH = 0x0d       # 13 bytes payload
 CMD_FAMILY_BREW = bytes([0x83, 0xf0])  # Brew beverage command family
 
+# Machine->app blob families. The machine wraps almost everything it stores in
+# the same `d0 <len> <family 2B> ... <crc16>` envelope, so the family bytes -
+# never the property name, which differs per model - say what a datapoint is.
+# See catalog.py for the grammar.
+BLOB_FAMILY_DESCRIPTOR = bytes([0xb0, 0xf0])       # factory min/default/max
+BLOB_FAMILY_PROFILE_RECIPE = bytes([0xa6, 0xf0])   # per-profile current values
+BLOB_FAMILY_MENU = bytes([0xa8, 0xf0])             # the machine's ordered menu
+BLOB_FAMILY_PROFILE_NAMES = bytes([0xa4, 0xf0])
+BLOB_FAMILY_CUSTOM_NAMES = bytes([0xaa, 0xf0])
+BLOB_FAMILY_BEAN_NAMES = bytes([0xba, 0xf0])
+
+# The families that carry text the household typed in. Their structure is safe
+# to log; their content is a first name.
+TEXT_BLOB_FAMILIES = frozenset(
+    {BLOB_FAMILY_PROFILE_NAMES, BLOB_FAMILY_CUSTOM_NAMES, BLOB_FAMILY_BEAN_NAMES}
+)
+# The families the recipe diagnostic may render. Deliberately NOT the whole
+# 0xd0 envelope: the serial number (family a1 0f), the settings PIN (95 0f),
+# the monitor blob (75 0f) and the response channel (a9 f0) wear it too, and
+# that dump is meant to be pasted into public issue reports.
+DUMPABLE_BLOB_FAMILIES = frozenset(
+    {
+        BLOB_FAMILY_DESCRIPTOR,
+        BLOB_FAMILY_PROFILE_RECIPE,
+        BLOB_FAMILY_MENU,
+        *TEXT_BLOB_FAMILIES,
+    }
+)
+
 # Eletta Explore (oem_model=DL-striker-cb) beverage frames carry a variable
 # length recipe block terminated by this 2-byte trailer, then the CRC. The Soul
 # (DL-millcore) frame has no trailer (fixed 6-byte recipe). See command_builder.

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -236,9 +236,8 @@ COUNTER_SENSORS = [
 MEASUREMENT_WATER_LITERS = "water_liters"
 
 # De'Longhi machines report water volumes in millilitres, while Home Assistant's
-# water device class works in litres. Sources: DeLonghi's own statistics sheet
-# is in litres, sk7n4k3d/delonghi-ha applies scale=0.001 to the same datapoints,
-# and PyDeLonghiAPI derives lifetime litres as d553 / 1000 (see issue #19).
+# water device class works in litres. Confirmed against De'Longhi's own
+# statistics sheet, which is denominated in litres (see issue #19).
 COUNTER_MEASUREMENTS: dict[str, str] = {
     "water_total_quantity": MEASUREMENT_WATER_LITERS,
     "water_filter_quantity": MEASUREMENT_WATER_LITERS,

--- a/custom_components/delonghi_coffeelink/coordinator.py
+++ b/custom_components/delonghi_coffeelink/coordinator.py
@@ -34,6 +34,12 @@ from .command_builder import (
     summarize_decoded,
     validate_replayed_wake_frame,
 )
+from .catalog import (
+    build_catalog,
+    catalog_beverage_ids,
+    catalog_fingerprint,
+    catalog_summary,
+)
 from .const import (
     ACTION_STOP,
     APP_ID_PROPERTY,
@@ -133,6 +139,12 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Status sensor; which datapoint it comes from is resolved per model
         # (see MONITOR_PROPERTY_CANDIDATES). Empty dict until a blob parses.
         self.monitor: dict[str, Any] = {}
+        # The machine's own beverage catalogue, parsed from the recipe datapoints
+        # already present in every poll (see catalog.py). Read-only for now: it
+        # widens the learn gate and feeds the diagnostic dump, and creates no
+        # entities. ``None`` until the first poll produces readable blobs.
+        self.catalog: dict[str, Any] | None = None
+        self._catalog_fingerprint: tuple | None = None
         self._store: Store = Store(
             hass, RECIPE_STORE_VERSION, f"{DOMAIN}_recipes_{device.dsn}"
         )
@@ -168,6 +180,9 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.connected_property = self._detect_property(
                     props, CONNECTED_PROPERTY_CANDIDATES, "connected", required=False
                 )
+            # Before sniffing: the learn gate consults the catalogue, so a frame
+            # captured on this very poll must be able to see the ids it declares.
+            self._update_catalog(props)
             self._sniff_app_traffic(props)
             self._update_monitor(props)
             self._update_session_from_props(props)
@@ -205,6 +220,48 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if value is not None:
                 decoded.append((candidate, parse_monitor_b64(value)))
         return decoded
+
+    def _update_catalog(self, props: dict[str, Any]) -> None:
+        """Rebuild the machine's beverage catalogue when its recipe blobs change.
+
+        Pure parse of properties already in hand - no extra request, no protocol
+        traffic. Recipes only change when someone edits one on the machine or in
+        the app, so a key over the catalogue datapoints (and only those, see
+        ``catalog_fingerprint``) keeps the ~4 ms parse off every poll where
+        nothing moved. The key is the values themselves, not their hash: a hash
+        collision would freeze the catalogue silently, which is the one failure
+        mode not worth trading for a few bytes.
+
+        Like the monitor decode, this is diagnostic-grade: it must never be able
+        to break a poll, so any unexpected failure keeps the previous catalogue.
+        """
+        try:
+            fingerprint = catalog_fingerprint(props)
+            if fingerprint == self._catalog_fingerprint and self.catalog is not None:
+                return
+            catalog = build_catalog(props)
+            if catalog["source"] == "empty":
+                # Nothing readable this time: keep whatever we had. A blank poll
+                # must never look like a machine that lost its recipes.
+                if self.catalog is None:
+                    _LOGGER.debug(
+                        "No machine beverage catalogue yet for dsn=%s "
+                        "(no readable recipe blobs in %d properties)",
+                        self.device.dsn,
+                        len(props),
+                    )
+                return
+            self._catalog_fingerprint = fingerprint
+            first = self.catalog is None
+            self.catalog = catalog
+            _LOGGER.log(
+                logging.INFO if first else logging.DEBUG,
+                "Machine beverage catalogue for dsn=%s: %s",
+                self.device.dsn,
+                catalog_summary(catalog),
+            )
+        except Exception:  # noqa: BLE001 - diagnostic must never break the poll
+            _LOGGER.debug("Beverage catalogue parse failed; keeping previous", exc_info=True)
 
     def _update_monitor(self, props: dict[str, Any]) -> None:
         """Decode the machine monitor blob (diagnostic; must never break the poll).
@@ -862,9 +919,10 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         lines = recipe_dump_lines(self.data)
         _LOGGER.warning(
             "=== DeLonghi recipe datapoint dump (dsn=%s, %d entries) BEGIN ===\n"
-            "%s\n=== recipe datapoint dump END ===",
+            "catalogue: %s\n%s\n=== recipe datapoint dump END ===",
             self.device.dsn,
             len(lines),
+            catalog_summary(self.catalog),
             "\n".join(lines),
         )
 
@@ -914,12 +972,16 @@ class DelonghiCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._refresh_device_app_id()
             return
 
-        bev_id = learnable_beverage_id(decoded)
+        # The machine's own declared ids widen the gate past the hardcoded list,
+        # so a saved recipe ("Perso 1", ids 0xe6-0xeb) or a bean-system drink
+        # brewed from the official app is captured instead of discarded.
+        bev_id = learnable_beverage_id(decoded, catalog_beverage_ids(self.catalog))
         if bev_id is None:
             if ftype == "beverage":
                 _LOGGER.debug(
                     "Not learning captured beverage frame (id=%s, crc_valid=%s): "
-                    "unknown beverage or invalid checksum",
+                    "beverage unknown to both the integration and the machine "
+                    "catalogue, or invalid checksum",
                     decoded.get("beverage_id"),
                     decoded.get("crc_valid"),
                 )

--- a/tests/fixtures/anonymise_dump.py
+++ b/tests/fixtures/anonymise_dump.py
@@ -1,0 +1,140 @@
+"""Rebuild ``soul_properties.json`` from a raw machine property dump.
+
+Kept next to the fixture so the anonymisation is reproducible and auditable
+rather than a one-off nobody can check. The dump is from a real machine, so
+before it can live in a public repository every identifier has to go:
+
+* ``d270_serialnumber`` - the ASCII serial is overwritten in place;
+* every blob carrying user-entered UTF-16BE text (families ``a4f0`` profile
+  names, ``aaf0`` custom-slot names, ``baf0`` bean names) gets a placeholder;
+* the Wi-Fi MAC address, which is three plain **integer** datapoints
+  (``d521``/``d522``/``d523``) rather than a blob - a scan that only looks at
+  the base64 strings walks straight past it.
+
+Selection is by blob **family**, not by property name - the same principle the
+parser uses, and the reason this catches ``d036_recipe_custom_name_1_3``, which
+a name-based rule missed. Each rewritten blob has its CRC recomputed, so the
+fixture still exercises the checksum path exactly as the machine's own bytes
+would; a blob the dump truncated is re-emitted at its original length so the
+truncation cases survive too.
+
+``test_catalog.py::test_the_fixture_carries_no_identifiers`` enforces the result.
+
+Usage: ``python anonymise_dump.py <raw-dump.txt> [out.json]``.
+"""
+import base64
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = sys.argv[1] if len(sys.argv) > 1 else os.path.join(HERE, "raw_dump.txt")
+OUT = sys.argv[2] if len(sys.argv) > 2 else os.path.join(HERE, "soul_properties.json")
+
+CRC_POLY, CRC_INIT = 0x1021, 0x1D0F
+def crc16(data):
+    crc = CRC_INIT
+    for b in data:
+        crc ^= b << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ CRC_POLY) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+    return crc
+
+LINE = re.compile(r"^\s*\[(\w+)\s+RO=(\w+)\]\s+(\S+)\s+=\s(.*?)\s+\((string|integer)\)\s*$")
+props = {}
+for line in open(SRC, encoding="utf-8", errors="replace"):
+    m = LINE.match(line.rstrip("\n"))
+    if not m:
+        continue
+    _dir, _ro, name, value, kind = m.groups()
+    props[name] = {"value": int(value) if kind == "integer" else value}
+# the two trailing channel props are printed without a (string) suffix on data_request
+for line in open(SRC, encoding="utf-8", errors="replace"):
+    m = re.match(r"^\s*\[(\w+)\s+RO=(\w+)\]\s+(\S+)\s+=\s(\S+)\s*$", line.rstrip("\n"))
+    if m and m.group(3) not in props:
+        props[m.group(3)] = {"value": m.group(4)}
+
+# Anonymise by blob FAMILY, not by property name - the same principle the parser uses.
+TEXT_FAMILIES = {b"\xa4\xf0": "Profile", b"\xba\xf0": "Bean", b"\xaa\xf0": "Slot"}
+
+def _decode_lenient(value):
+    """Decode a possibly truncated base64 value: keep the largest 4-char multiple."""
+    clean = "".join(value.split())
+    return bytearray(base64.b64decode(clean[: len(clean) // 4 * 4]))
+
+
+def _reencode(raw, original):
+    """Re-emit, preserving the original truncation (same base64 char count)."""
+    out = base64.b64encode(bytes(raw)).decode()
+    clean = "".join(original.split())
+    return out if len(clean) % 4 == 0 else out[: len(clean)]
+
+
+def anonymise_text(name, value):
+    raw = _decode_lenient(value)
+    if len(raw) < 8 or raw[0] != 0xD0:
+        return value
+    fam = bytes(raw[2:4])
+    label = TEXT_FAMILIES.get(fam)
+    if label is None:
+        return value
+    complete = raw[1] + 1 <= len(raw)
+    end = (raw[1] + 1 - 2) if complete else len(raw)
+    idx = raw[4]
+    filler = f"{label} {idx + 1}".encode("utf-16-be")
+    region = bytearray(end - 6)
+    region[: len(filler)] = filler[: len(region)]
+    raw[6:end] = region
+    if complete:
+        raw[raw[1] - 1 : raw[1] + 1] = crc16(bytes(raw[: raw[1] - 1])).to_bytes(2, "big")
+    return _reencode(raw, value)
+
+def anonymise_serial(value):
+    raw = _decode_lenient(value)
+    fake = b"000000XX00000000000"
+    i = raw.find(b"217065")
+    if i >= 0:
+        raw[i : i + len(fake)] = fake
+        if raw[1] + 1 <= len(raw):
+            raw[raw[1] - 1 : raw[1] + 1] = crc16(bytes(raw[: raw[1] - 1])).to_bytes(2, "big")
+    return _reencode(raw, value)
+
+# Integer identifiers: the radio MAC is three 16-bit words. Nothing in
+# catalog.py reads them, so they can be blanked outright.
+MAC_PROPERTIES = ("d521_radio_mac_addr0", "d522_radio_mac_addr1", "d523_radio_mac_addr2")
+for name in MAC_PROPERTIES:
+    if name in props:
+        props[name]["value"] = 0
+
+for name, prop in props.items():
+    v = prop["value"]
+    if not isinstance(v, str):
+        continue
+    if name == "d270_serialnumber":
+        prop["value"] = anonymise_serial(v)
+    else:
+        try:
+            prop["value"] = anonymise_text(name, v)
+        except Exception as exc:  # noqa: BLE001
+            print("skip", name, exc)
+
+# scrub any residual identifying ASCII / UTF-16 text
+leaks = []
+for name, prop in props.items():
+    v = prop["value"]
+    if isinstance(v, str) and len(v) > 8:
+        try:
+            raw = bytes(_decode_lenient(v))
+        except Exception:
+            continue
+        txt = raw.decode("utf-16-be", "ignore") + raw.decode("latin-1", "ignore")
+        for needle in ("Veronica", "Guill", "217065", "AC000W", "Kimbo", "eden", "Neo Bio", "Perso"):
+            if needle.lower() in txt.lower():
+                leaks.append((name, needle))
+for name in MAC_PROPERTIES:
+    assert props.get(name, {}).get("value") == 0, name
+print("properties:", len(props), "| residual leaks:", leaks)
+os.makedirs(os.path.dirname(OUT), exist_ok=True)
+json.dump(props, open(OUT, "w", encoding="utf-8"), indent=1, sort_keys=True)
+print("written", OUT)

--- a/tests/fixtures/soul_properties.json
+++ b/tests/fixtures/soul_properties.json
@@ -1,0 +1,938 @@
+{
+ "d001_rec_espresso": {
+  "value": "0CWw8AEIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBuZ"
+ },
+ "d002_rec_regular": {
+  "value": "0CGw8AIYAAEBGQABARsAAQQBAGQAtADwAgADBQQAAAAAzA=="
+ },
+ "d003_rec_long_coffee": {
+  "value": "0CGw8AMYAAEBGQABAQEAcwCgAPobAAEEAgADBQQAAAB65A=="
+ },
+ "d004_rec_2x_espresso": {
+  "value": "0CWw8AQIAQEBGAAAAAEAKABQAWgbAAEEAgAEBQQAAAAZAAEBlh"
+ },
+ "d005_rec_doppio": {
+  "value": "0B2w8AUYAAEBGQABAQEAUAB4ALQbAAEEBAAAADiZ"
+ },
+ "d006_rec_americano": {
+  "value": "0Ciw8AYYAAEBGQABAQEAFAAoALQPADIAbgEsGwABBAIAAwUEAA"
+ },
+ "d007_rec_cappuccino": {
+  "value": "0Cyw8AccAgICGAABARkAAQEBABQAQQC0GwABBAIAAwUJADIAqg"
+ },
+ "d008_rec_latte_macchiato": {
+  "value": "0Cyw8AgcAgICGAABARkAAQEBABQAPAC0GwABBAIAAwUJADIBIg"
+ },
+ "d009_rec_caffelatte": {
+  "value": "0Cyw8AkcAgICGAABARkAAQEBABQAPAC0GwABBAIAAwUJADIBfA"
+ },
+ "d010_rec_flat_white": {
+  "value": "0DCw8AoMAQEBHAICAhgAAQEZAAEBAQAUADwAtBsAAQQCAAMFCQ"
+ },
+ "d011_rec_espr_macchiato": {
+  "value": "0Cyw8AscAgICGAABARkAAQEBABQAHgC0GwABBAIAAwUJAB4AKA"
+ },
+ "d012_rec_hot_milk": {
+  "value": "0B2w8AwcAgICGAABARkAAQEJADIBaAQ4GwABBAf0"
+ },
+ "d013_rec_capp_doppio": {
+  "value": "0Ciw8A0cAgICGAABARkAAQEBAFAAZAC0GwABBAkAMgCWBDgEAA"
+ },
+ "d014_rec_capp_reverse": {
+  "value": "0DCw8A8MAQEBHAICAhgAAQEZAAEBAQAUAEEAtBsAAQQCAAMFCQ"
+ },
+ "d015_rec_hot_water": {
+  "value": "0Bmw8BAYAAEBGQABAQ8AFAD6AaQbAAEEN5Y="
+ },
+ "d016_rec_tea": {
+  "value": "0B2w8BYYAAEBGQACAg8AFACWAaQbAAEEDQABA64W"
+ },
+ "d017_rec_coffee_pot": {
+  "value": "0CGw8BcZAAICAQB9AJYA+hsAAQMEAAAAHgAABQIFBQV1uA=="
+ },
+ "d018_rec_cortado": {
+  "value": "0DCw8BgMAQEBHAICAhgAAQEZAAEBAQAUACgAtBsAAQQCAAMFCQ"
+ },
+ "d019_rec_long_black": {
+  "value": "0CWw8BkIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBly"
+ },
+ "d020_rec_mug_to_go": {
+  "value": "0CWw8BoIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBfO"
+ },
+ "d021_rec_brew_over_ice": {
+  "value": "0CWw8BsIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBJa"
+ },
+ "d022_beansystem_1": {
+  "value": "0B2w8MgYAAEBAQAeACgAPBsAAQQCAQQFGQACAoMB"
+ },
+ "d028_rec_custom_1": {
+  "value": "0Cyw8OYYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d029_rec_custom_2": {
+  "value": "0Cyw8OcYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d030_rec_custom_3": {
+  "value": "0Cyw8OgYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d031_rec_custom_4": {
+  "value": "0Cyw8OkYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d032_rec_custom_5": {
+  "value": "0Cyw8OoYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d033_rec_custom_6": {
+  "value": "0Cyw8OsYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAA"
+ },
+ "d034_profiles_1_3": {
+  "value": "0Eek8AEDAFAAcgBvAGYAaQBsAGUAIAAyAAAAAAAAAAAAAAAA"
+ },
+ "d035_profiles_4_5": {
+  "value": "0Aik8AQFAEtE"
+ },
+ "d036_recipe_custom_name_1_3": {
+  "value": "0Eaq8AEDAFMAbABvAHQAIAAyAAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d037_recipe_custom_name_4_5": {
+  "value": "0Eaq8AQGAFMAbABvAHQAIAA1AAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d039_1_rec_espresso": {
+  "value": "0BSm8AEBCAABADAbAgIEBAAZAQFp"
+ },
+ "d040_1_rec_regular": {
+  "value": "0BKm8AECGQEbAQEAtAIDBAAKng=="
+ },
+ "d041_1_rec_long_coffee": {
+  "value": "0BKm8AEDGQEBAKAbAQIDBABbfw=="
+ },
+ "d042_1_rec_2x_espresso": {
+  "value": "0BSm8AEECAEBAGAbAgIEBAAZAYj/"
+ },
+ "d043_1_rec_doppio": {
+  "value": "0BCm8AEFGQEBAHgbAQQAnXY="
+ },
+ "d044_1_rec_americano": {
+  "value": "0BWm8AEGGQEBACgPAG4bAQIDBAAyqA=="
+ },
+ "d045_1_rec_cappuccino": {
+  "value": "0Bem8AEHHAIZAQEAThsCAgMJAMwEAN8z"
+ },
+ "d046_1_rec_latte_macchiato": {
+  "value": "0Bem8AEIHAIZAQEASBsCAgMJAVwEAFe/"
+ },
+ "d047_1_rec_caffelatte": {
+  "value": "0Bem8AEJHAIZAQEAPBsBAgMJAXwEAHta"
+ },
+ "d048_1_rec_flat_white": {
+  "value": "0Bmm8AEKDAEcAhkBAQA8GwECAwkA3AQAeyM="
+ },
+ "d049_1_rec_espr_macchiato": {
+  "value": "0Bem8AELHAIZAQEAHhsBAgMJACgEAEmj"
+ },
+ "d050_1_rec_hot_milk": {
+  "value": "0BCm8AEMHAIZAQkBaBsBJPo="
+ },
+ "d051_1_rec_capp_doppio": {
+  "value": "0BWm8AENHAIZAQEAZBsBCQCWBABQVg=="
+ },
+ "d052_1_rec_capp_reverse": {
+  "value": "0Bmm8AEPDAEcAhkBAQBBGwECAwkAqgQA0DE="
+ },
+ "d053_1_rec_hot_water": {
+  "value": "0A6m8AEQGQEPAPobAU9C"
+ },
+ "d054_1_rec_tea": {
+  "value": "0BCm8AEWGQIPAJYbAQ0BHM8="
+ },
+ "d055_1_rec_coffee_pot": {
+  "value": "0BKm8AEXGQIBAJYbAQQAAgWsVg=="
+ },
+ "d056_1_rec_cortado": {
+  "value": "0Bmm8AEYDAEcAhkBAQAoGwECAwkAKAQA4VA="
+ },
+ "d057_1_rec_long_black": {
+  "value": "0BSm8AEZCAABADAbAgIEBAAZASz1"
+ },
+ "d058_1_rec_mug_to_go": {
+  "value": "0BSm8AEaCAABADAbAgIEBAAZAaFW"
+ },
+ "d059_1_rec_brew_over_ice": {
+  "value": "0BSm8AEbCAABADAbAgIEBAAZAdo3"
+ },
+ "d060_2_rec_espresso": {
+  "value": "0BSm8AIBCAABACgbAQIEBAAZAUDP"
+ },
+ "d061_2_rec_regular": {
+  "value": "0BKm8AICGQEbAQEAtAIDBADFOw=="
+ },
+ "d062_2_rec_long_coffee": {
+  "value": "0BKm8AIDGQEBAKAbAQIDBACU2g=="
+ },
+ "d063_2_rec_2x_espresso": {
+  "value": "0BSm8AIECAEBAFAbAQIEBAAZAUda"
+ },
+ "d064_2_rec_doppio": {
+  "value": "0BCm8AIFGQEBAHgbAQQA5Yw="
+ },
+ "d065_2_rec_americano": {
+  "value": "0BWm8AIGGQEBACgPAG4bAQIDBADa5Q=="
+ },
+ "d066_2_rec_cappuccino": {
+  "value": "0Bem8AIHHAIZAQEAThsCAgMJAMwEAN9B"
+ },
+ "d067_2_rec_latte_macchiato": {
+  "value": "0Bem8AIIHAIZAQEAPBsBAgMJASIEAC4F"
+ },
+ "d068_2_rec_caffelatte": {
+  "value": "0Bem8AIJHAIZAQEAPBsBAgMJAXwEAHso"
+ },
+ "d069_2_rec_flat_white": {
+  "value": "0Bmm8AIKDAEcAhkBAQA8GwECAwkA3AQAJfY="
+ },
+ "d070_2_rec_espr_macchiato": {
+  "value": "0Bem8AILHAIZAQEAHhsBAgMJACgEAEnR"
+ },
+ "d071_2_rec_hot_milk": {
+  "value": "0BCm8AIMHAIZAQkBaBsBXAA="
+ },
+ "d072_2_rec_capp_doppio": {
+  "value": "0BWm8AINHAIZAQEAZBsBCQCWBAC4Gw=="
+ },
+ "d073_2_rec_capp_reverse": {
+  "value": "0Bmm8AIPDAEcAhkBAQBBGwECAwkAqgQAjuQ="
+ },
+ "d074_2_rec_hot_water": {
+  "value": "0A6m8AIQGQEPAPobAWIG"
+ },
+ "d075_2_rec_tea": {
+  "value": "0BCm8AIWGQIPAOEbAw0CQGQ="
+ },
+ "d076_2_rec_coffee_pot": {
+  "value": "0BKm8AIXGQIBAJYbAQQAAgVj8w=="
+ },
+ "d077_2_rec_cortado": {
+  "value": "0Bmm8AIYDAEcAhkBAQAoGwECAwkAKAQAv4U="
+ },
+ "d078_2_rec_long_black": {
+  "value": "0BSm8AIZCAABACgbAQIEBAAZAW1T"
+ },
+ "d079_2_rec_mug_to_go": {
+  "value": "0BSm8AIaCAABACgbAQIEBAAZAeDw"
+ },
+ "d080_2_rec_brew_over_ice": {
+  "value": "0BSm8AIbCAABACgbAQIEBAAZAZuR"
+ },
+ "d081_3_rec_espresso": {
+  "value": "0BSm8AMBCAABACgbAQIEBAAZAe4z"
+ },
+ "d082_3_rec_regular": {
+  "value": "0BKm8AMCGQEbAQEAtAIDBACAWA=="
+ },
+ "d083_3_rec_long_coffee": {
+  "value": "0BKm8AMDGQEBAKAbAQIDBADRuQ=="
+ },
+ "d084_3_rec_2x_espresso": {
+  "value": "0BSm8AMECAEBAFAbAQIEBAAZAemm"
+ },
+ "d085_3_rec_doppio": {
+  "value": "0BCm8AMFGQEBAHgbAQQAPcU="
+ },
+ "d086_3_rec_americano": {
+  "value": "0BWm8AMGGQEBACgPAG4bAQIDBABywQ=="
+ },
+ "d087_3_rec_cappuccino": {
+  "value": "0Bem8AMHHAIZAQEAQRsBAgMJAKoEAJh/"
+ },
+ "d088_3_rec_latte_macchiato": {
+  "value": "0Bem8AMIHAIZAQEAPBsBAgMJASIEAN40"
+ },
+ "d089_3_rec_caffelatte": {
+  "value": "0Bem8AMJHAIZAQEAPBsBAgMJAXwEAIsZ"
+ },
+ "d090_3_rec_flat_white": {
+  "value": "0Bmm8AMKDAEcAhkBAQA8GwECAwkA3AQAEEU="
+ },
+ "d091_3_rec_espr_macchiato": {
+  "value": "0Bem8AMLHAIZAQEAHhsBAgMJACgEALng"
+ },
+ "d092_3_rec_hot_milk": {
+  "value": "0BCm8AMMHAIZAQkBaBsBhEk="
+ },
+ "d093_3_rec_capp_doppio": {
+  "value": "0BWm8AMNHAIZAQEAZBsBCQCWBAAQPw=="
+ },
+ "d094_3_rec_capp_reverse": {
+  "value": "0Bmm8AMPDAEcAhkBAQBBGwECAwkAqgQAu1c="
+ },
+ "d095_3_rec_hot_water": {
+  "value": "0A6m8AMQGQEPAPobAYkl"
+ },
+ "d096_3_rec_tea": {
+  "value": "0BCm8AMWGQIPAJYbAQ0BvHw="
+ },
+ "d097_3_rec_coffee_pot": {
+  "value": "0BKm8AMXGQIBAJYbAQQAAgUmkA=="
+ },
+ "d098_3_rec_cortado": {
+  "value": "0Bmm8AMYDAEcAhkBAQAoGwECAwkAKAQAijY="
+ },
+ "d099_3_rec_long_black": {
+  "value": "0BSm8AMZCAABACgbAQIEBAAZAcOv"
+ },
+ "d100_3_rec_mug_to_go": {
+  "value": "0BSm8AMaCAABACgbAQIEBAAZAU4M"
+ },
+ "d101_3_rec_brew_over_ice": {
+  "value": "0BSm8AMbCAABACgbAQIEBAAZATVt"
+ },
+ "d102_4_rec_espresso": {
+  "value": "0BSm8AQBCAABADAbAgIEBAAZATQn"
+ },
+ "d103_4_rec_regular": {
+  "value": "0BKm8AQCGQEbAQEAtAIDBABKUA=="
+ },
+ "d104_4_rec_long_coffee": {
+  "value": "0BKm8AQDGQEBAKAbAQIDBAAbsQ=="
+ },
+ "d105_4_rec_2x_espresso": {
+  "value": "0BSm8AQECAEBAGAbAgIEBAAZAb2x"
+ },
+ "d106_4_rec_doppio": {
+  "value": "0BCm8AQFGQEBAHgbAQQAFHg="
+ },
+ "d107_4_rec_americano": {
+  "value": "0BWm8AQGGQEBACgPAG4bAQIDBAAaXg=="
+ },
+ "d108_4_rec_cappuccino": {
+  "value": "0Bem8AQHHAIZAQEAThsCAgMJAMwEAN+l"
+ },
+ "d109_4_rec_latte_macchiato": {
+  "value": "0Bem8AQIHAIZAQEASBsCAgMJAVwEAFcp"
+ },
+ "d110_4_rec_caffelatte": {
+  "value": "0Bem8AQJHAIZAQEAPBsBAgMJAXwEAHvM"
+ },
+ "d111_4_rec_flat_white": {
+  "value": "0Bmm8AQKDAEcAhkBAQA8GwECAwkA3AQAmFw="
+ },
+ "d112_4_rec_espr_macchiato": {
+  "value": "0Bem8AQLHAIZAQEAHhsBAgMJACgEAEk1"
+ },
+ "d113_4_rec_hot_milk": {
+  "value": "0BCm8AQMHAIZAQkBaBsBrfQ="
+ },
+ "d114_4_rec_capp_doppio": {
+  "value": "0BWm8AQNHAIZAQEAZBsBCQCWBAB4oA=="
+ },
+ "d115_4_rec_capp_reverse": {
+  "value": "0Bmm8AQPDAEcAhkBAQBBGwECAwkAqgQAM04="
+ },
+ "d116_4_rec_hot_water": {
+  "value": "0A6m8AQQGQEPAPobATiO"
+ },
+ "d117_4_rec_tea": {
+  "value": "0BCm8AQWGQIPAJYbAQ0BlcE="
+ },
+ "d118_4_rec_coffee_pot": {
+  "value": "0BKm8AQXGQIBAJYbAQQAAgXsmA=="
+ },
+ "d119_4_rec_cortado": {
+  "value": "0Bmm8AQYDAEcAhkBAQAoGwECAwkAKAQAAi8="
+ },
+ "d120_4_rec_long_black": {
+  "value": "0BSm8AQZCAABADAbAgIEBAAZARm7"
+ },
+ "d121_4_rec_mug_to_go": {
+  "value": "0BSm8AQaCAABADAbAgIEBAAZAZQY"
+ },
+ "d122_4_rec_brew_over_ice": {
+  "value": "0BSm8AQbCAABADAbAgIEBAAZAe95"
+ },
+ "d123_5_rec_espresso": {
+  "value": "0BSm8AUBCAABADAbAgIEBAAZAZrb"
+ },
+ "d124_5_rec_regular": {
+  "value": "0BKm8AUCGQEbAQEAtAIDBAAPMw=="
+ },
+ "d125_5_rec_long_coffee": {
+  "value": "0BKm8AUDGQEBAKAbAQIDBABe0g=="
+ },
+ "d126_5_rec_2x_espresso": {
+  "value": "0BSm8AUECAEBAGAbAgIEBAAZARNN"
+ },
+ "d127_5_rec_doppio": {
+  "value": "0BCm8AUFGQEBAHgbAQQAzDE="
+ },
+ "d128_5_rec_americano": {
+  "value": "0BWm8AUGGQEBACgPAG4bAQIDBACyeg=="
+ },
+ "d129_5_rec_cappuccino": {
+  "value": "0Bem8AUHHAIZAQEAThsCAgMJAMwEAC+U"
+ },
+ "d130_5_rec_latte_macchiato": {
+  "value": "0Bem8AUIHAIZAQEASBsCAgMJAVwEAKcY"
+ },
+ "d131_5_rec_caffelatte": {
+  "value": "0Bem8AUJHAIZAQEAPBsBAgMJAXwEAIv9"
+ },
+ "d132_5_rec_flat_white": {
+  "value": "0Bmm8AUKDAEcAhkBAQA8GwECAwkA3AQAre8="
+ },
+ "d133_5_rec_espr_macchiato": {
+  "value": "0Bem8AULHAIZAQEAHhsBAgMJACgEALkE"
+ },
+ "d134_5_rec_hot_milk": {
+  "value": "0BCm8AUMHAIZAQkBaBsBdb0="
+ },
+ "d135_5_rec_capp_doppio": {
+  "value": "0BWm8AUNHAIZAQEAZBsBCQCWBADQhA=="
+ },
+ "d136_5_rec_capp_reverse": {
+  "value": "0Bmm8AUPDAEcAhkBAQBBGwECAwkAqgQABv0="
+ },
+ "d137_5_rec_hot_water": {
+  "value": "0A6m8AUQGQEPAPobAdOt"
+ },
+ "d138_5_rec_tea": {
+  "value": "0BCm8AUWGQIPAJYbAQ0BTYg="
+ },
+ "d139_5_rec_coffee_pot": {
+  "value": "0BKm8AUXGQIBAJYbAQQAAgWp+w=="
+ },
+ "d140_5_rec_cortado": {
+  "value": "0Bmm8AUYDAEcAhkBAQAoGwECAwkAKAQAN5w="
+ },
+ "d141_5_rec_long_black": {
+  "value": "0BSm8AUZCAABADAbAgIEBAAZAbdH"
+ },
+ "d142_5_rec_mug_to_go": {
+  "value": "0BSm8AUaCAABADAbAgIEBAAZATrk"
+ },
+ "d143_5_rec_brew_over_ice": {
+  "value": "0BSm8AUbCAABADAbAgIEBAAZAUGF"
+ },
+ "d160_1_bs_recipe_01": {
+  "value": "0BCm8AHIAQAwGwICAhkBCd0="
+ },
+ "d166_2_bs_recipe_01": {
+  "value": "0BCm8ALIAQAgGwACAhkBAt8="
+ },
+ "d172_3_bs_recipe_01": {
+  "value": "0BCm8APIAQAoGwECAhkB42o="
+ },
+ "d178_4_bs_recipe_01": {
+  "value": "0BCm8ATIAQAwGwICAhkBgNM="
+ },
+ "d184_5_bs_recipe_01": {
+  "value": "0BCm8AXIAQAwGwICAhkBWJo="
+ },
+ "d200_1_cstm_recipe_01": {
+  "value": "0Bem8AHmAQAAAv8JAAAEAAwAHAAZABK3"
+ },
+ "d201_1_cstm_recipe_02": {
+  "value": "0Bem8AHnAQAAAv8JAAAEAAwAHAAZAAJV"
+ },
+ "d202_1_cstm_recipe_03": {
+  "value": "0Bem8AHoAQAAAv8JAAAEAAwAHAAZAPfr"
+ },
+ "d203_1_cstm_recipe_04": {
+  "value": "0Bem8AHpAQAAAv8JAAAEAAwAHAAZAOcJ"
+ },
+ "d204_1_cstm_recipe_05": {
+  "value": "0Bem8AHqAQAAAv8JAAAEAAwAHAAZANYv"
+ },
+ "d205_1_cstm_recipe_06": {
+  "value": "0Bem8AHrAQAAAv8JAAAEAAwAHAAZAMbN"
+ },
+ "d206_2_cstm_recipe_01": {
+  "value": "0Bem8ALmAQAAAv8JAAAEAAwAHAAZABLF"
+ },
+ "d207_2_cstm_recipe_02": {
+  "value": "0Bem8ALnAQAAAv8JAAAEAAwAHAAZAAIn"
+ },
+ "d208_2_cstm_recipe_03": {
+  "value": "0Bem8ALoAQAAAv8JAAAEAAwAHAAZAPeZ"
+ },
+ "d209_2_cstm_recipe_04": {
+  "value": "0Bem8ALpAQAAAv8JAAAEAAwAHAAZAOd7"
+ },
+ "d210_2_cstm_recipe_05": {
+  "value": "0Bem8ALqAQAAAv8JAAAEAAwAHAAZANZd"
+ },
+ "d211_2_cstm_recipe_06": {
+  "value": "0Bem8ALrAQAAAv8JAAAEAAwAHAAZAMa/"
+ },
+ "d212_3_cstm_recipe_01": {
+  "value": "0Bem8APmAQAAAv8JAAAEAAwAHAAZAOL0"
+ },
+ "d213_3_cstm_recipe_02": {
+  "value": "0Bem8APnAQAAAv8JAAAEAAwAHAAZAPIW"
+ },
+ "d214_3_cstm_recipe_03": {
+  "value": "0Bem8APoAQAAAv8JAAAEAAwAHAAZAAeo"
+ },
+ "d215_3_cstm_recipe_04": {
+  "value": "0Bem8APpAQAAAv8JAAAEAAwAHAAZABdK"
+ },
+ "d216_3_cstm_recipe_05": {
+  "value": "0Bem8APqAQAAAv8JAAAEAAwAHAAZACZs"
+ },
+ "d217_3_cstm_recipe_06": {
+  "value": "0Bem8APrAQAAAv8JAAAEAAwAHAAZADaO"
+ },
+ "d218_4_cstm_recipe_01": {
+  "value": "0Bem8ATmAQAAAv8JAAAEAAwAHAAZABIh"
+ },
+ "d219_4_cstm_recipe_02": {
+  "value": "0Bem8ATnAQAAAv8JAAAEAAwAHAAZAALD"
+ },
+ "d220_4_cstm_recipe_03": {
+  "value": "0Bem8AToAQAAAv8JAAAEAAwAHAAZAPd9"
+ },
+ "d221_4_cstm_recipe_04": {
+  "value": "0Bem8ATpAQAAAv8JAAAEAAwAHAAZAOef"
+ },
+ "d222_4_cstm_recipe_05": {
+  "value": "0Bem8ATqAQAAAv8JAAAEAAwAHAAZANa5"
+ },
+ "d223_4_cstm_recipe_06": {
+  "value": "0Bem8ATrAQAAAv8JAAAEAAwAHAAZAMZb"
+ },
+ "d224_5_cstm_recipe_01": {
+  "value": "0Bem8AXmAQAAAv8JAAAEAAwAHAAZAOIQ"
+ },
+ "d225_5_cstm_recipe_02": {
+  "value": "0Bem8AXnAQAAAv8JAAAEAAwAHAAZAPLy"
+ },
+ "d226_5_cstm_recipe_03": {
+  "value": "0Bem8AXoAQAAAv8JAAAEAAwAHAAZAAdM"
+ },
+ "d227_5_cstm_recipe_04": {
+  "value": "0Bem8AXpAQAAAv8JAAAEAAwAHAAZABeu"
+ },
+ "d228_5_cstm_recipe_05": {
+  "value": "0Bem8AXqAQAAAv8JAAAEAAwAHAAZACaI"
+ },
+ "d229_5_cstm_recipe_06": {
+  "value": "0Bem8AXrAQAAAv8JAAAEAAwAHAAZADZq"
+ },
+ "d250_beansystem_0": {
+  "value": "0DS68AAAAEIAZQBhAG4AIAAxAAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d251_beansystem_1": {
+  "value": "0DS68AEAAEIAZQBhAG4AIAAyAAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d252_beansystem_2": {
+  "value": "0DS68AIAAEIAZQBhAG4AIAAzAAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d253_beansystem_3": {
+  "value": "0DS68AMAAEIAZQBhAG4AIAA0AAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d254_beansystem_4": {
+  "value": "0DS68AQAAEIAZQBhAG4AIAA1AAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d255_beansystem_5": {
+  "value": "0DS68AUAAEIAZQBhAG4AIAA2AAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d256_beansystem_6": {
+  "value": "0DS68AYAAEIAZQBhAG4AIAA3AAAAAAAAAAAAAAAAAAAAAAAA"
+ },
+ "d260_beansystem_sync_par": {
+  "value": "0C+hDwH0AAAALAAAGgAAACnqAAAg0AAAAAEAAAIpAAAAAAAAAA"
+ },
+ "d261_1_rec_priority": {
+  "value": "0Bmo8AHIBQgHAwYMEAQWAQsXAgkKDQ8YyUs="
+ },
+ "d262_2_rec_priority": {
+  "value": "0Bmo8ALICAcQFgwLAQMECQINFwoGBQ8Yxqo="
+ },
+ "d263_3_rec_priority": {
+  "value": "0Bmo8APIAQQDBwkXCAoGBQsMAg0PGBAWoKg="
+ },
+ "d264_4_rec_priority": {
+  "value": "0Bmo8ATIBQgHAwYMEAQWAQsXAgkKDQ8YKjQ="
+ },
+ "d265_5_rec_priority": {
+  "value": "0Bmo8AXIBQgHAwYMEAQWAQsXAgkKDQ8YH4c="
+ },
+ "d270_serialnumber": {
+  "value": "0BuhDwDNMDAwMDAwWFgwMDAwMDAwMDAwMAByWA=="
+ },
+ "d280_mchn_sett_pin": {
+  "value": "0AuVDwDSAAAXDojT"
+ },
+ "d281_mchn_sett_temp": {
+  "value": "0AuVDwA9AAAAA51v"
+ },
+ "d282_mchn_sett_aoff": {
+  "value": "0AuVDwA+AAAAAVP/"
+ },
+ "d283_mchn_sett_water": {
+  "value": "0AuVDwAyAAAAAMj1"
+ },
+ "d284_mchn_sett_user_conf": {
+  "value": "0AuVDwA/AAAAHSoT"
+ },
+ "d285_mchn_sett_radio_conf": {
+  "value": "0AuVDwAtAAAAA5k1"
+ },
+ "d302_monitor": {
+  "value": "0BJ1DwAAAAQABwAAAAAAAAB7lmnoxeg="
+ },
+ "d303_monitor_extended": {
+  "value": "None"
+ },
+ "d500_machine_sett_factory_0": {
+  "value": 99
+ },
+ "d501_machine_sett_factory_1": {
+  "value": 0
+ },
+ "d510_ground_cnt_percentage": {
+  "value": 82
+ },
+ "d511_ground_cnt_pod_space": {
+  "value": 2
+ },
+ "d512_percentage_to_deca": {
+  "value": 66
+ },
+ "d513_percentage_usage_fltr": {
+  "value": 0
+ },
+ "d514_nbr_cups": {
+  "value": 0
+ },
+ "d520_radio_conf": {
+  "value": 3
+ },
+ "d521_radio_mac_addr0": {
+  "value": 0
+ },
+ "d522_radio_mac_addr1": {
+  "value": 0
+ },
+ "d523_radio_mac_addr2": {
+  "value": 0
+ },
+ "d524_ix_calcare_alm_qty": {
+  "value": 0
+ },
+ "d525_max_pos": {
+  "value": 0
+ },
+ "d526_ix_coffee_temp": {
+  "value": 0
+ },
+ "d527_ix_turn_off_time": {
+  "value": 0
+ },
+ "d528_user_conf": {
+  "value": 0
+ },
+ "d530_machine_conf": {
+  "value": 0
+ },
+ "d531_bt_first_connection": {
+  "value": 0
+ },
+ "d532_turn_on_wash_en": {
+  "value": 1
+ },
+ "d533_active_minutes": {
+  "value": 0
+ },
+ "d534_inertia_1": {
+  "value": 0
+ },
+ "d535_grinder_qerror_1": {
+  "value": 29000
+ },
+ "d536_absolute_position_mc1": {
+  "value": 32000
+ },
+ "d537_step_to_switch_mc1": {
+  "value": 1008
+ },
+ "d538_default_pos_mc1": {
+  "value": 776
+ },
+ "d539_default_pos_mc1set": {
+  "value": 0
+ },
+ "d540_mc1_granulometry": {
+  "value": 2056
+ },
+ "d550_water_calc_qty": {
+  "value": 3315920
+ },
+ "d551_cnt_coffee_fondi": {
+  "value": 1927
+ },
+ "d552_cnt_calc_tot": {
+  "value": 0
+ },
+ "d553_water_tot_qty": {
+  "value": 0
+ },
+ "d554_cnt_filter_tot": {
+  "value": 0
+ },
+ "d555_water_filter_qty": {
+  "value": 0
+ },
+ "d556_water_hardness": {
+  "value": 0
+ },
+ "d557_milk_cln_cnt": {
+  "value": 0
+ },
+ "d558_bev_cnt_desc_on": {
+  "value": 16
+ },
+ "d559_num_ix_coffee_temp": {
+  "value": 0
+ },
+ "d560_versione_sw": {
+  "value": 12
+ },
+ "d561_machine_model": {
+  "value": 859
+ },
+ "d562_versione_sw_ui": {
+  "value": 12
+ },
+ "d563_type_board_ui": {
+  "value": 1704641
+ },
+ "d565_product_key": {
+  "value": 1553
+ },
+ "d566_bt_sn_write": {
+  "value": 0
+ },
+ "d567_select_steamer": {
+  "value": 0
+ },
+ "d568_select_heater": {
+  "value": 0
+ },
+ "d569_bt_sw_version": {
+  "value": 131072
+ },
+ "d570_bt_micro_sw_version": {
+  "value": 0
+ },
+ "d571_stepper_st_recovery_a": {
+  "value": 0
+ },
+ "d572_stepper_st_recovery_b": {
+  "value": 0
+ },
+ "d700_tot_bev_b": {
+  "value": 2397
+ },
+ "d701_tot_bev_bw": {
+  "value": 691
+ },
+ "d702_tot_bev_other": {
+  "value": 139
+ },
+ "d703_tot_bev_w": {
+  "value": 130
+ },
+ "d704_tot_bev_espressi": {
+  "value": 2079
+ },
+ "d705_tot_id1_espr": {
+  "value": 94
+ },
+ "d706_tot_id2_coffee": {
+  "value": 6
+ },
+ "d707_tot_id3_long": {
+  "value": 133
+ },
+ "d708_tot_id5_doppio_p": {
+  "value": 83
+ },
+ "d709_id6_americano": {
+  "value": 96
+ },
+ "d710_tot_id7_capp": {
+  "value": 200
+ },
+ "d711_id8_lattmacc": {
+  "value": 462
+ },
+ "d712_id9_cafflatt": {
+  "value": 3
+ },
+ "d713_id10_flatwhite": {
+  "value": 0
+ },
+ "d714_id11_esprmacc": {
+  "value": 24
+ },
+ "d715_id12_hotmilk": {
+  "value": 130
+ },
+ "d716_id13_cappdoppio_p": {
+  "value": 2
+ },
+ "d717_id15_caprev": {
+  "value": 0
+ },
+ "d718_id16_hotwater": {
+  "value": 0
+ },
+ "d719_id22_tea": {
+  "value": 94
+ },
+ "d720_tot_id23_coffee_pot": {
+  "value": 1
+ },
+ "d721_id200_bs_1": {
+  "value": 0
+ },
+ "d722_id201_bs_2": {
+  "value": 0
+ },
+ "d723_id202_bs_3": {
+  "value": 0
+ },
+ "d724_id203_bs_4": {
+  "value": 0
+ },
+ "d725_id204_bs_5": {
+  "value": 1985
+ },
+ "d726_id205_bs_6": {
+  "value": 0
+ },
+ "d727_id24_cortado": {
+  "value": 0
+ },
+ "d728_id25_long_black": {
+  "value": 0
+ },
+ "d729_id26_travel_mug": {
+  "value": 0
+ },
+ "d730_tot_id27_brew_over_ice": {
+  "value": 0
+ },
+ "d731_pregr_coff_cnt": {
+  "value": 0
+ },
+ "d732_taste_b_bw": {
+  "value": 0
+ },
+ "d733_taste_espressi": {
+  "value": 0
+ },
+ "d734_taste_coffee": {
+  "value": 0
+ },
+ "d735_b_water_qty": {
+  "value": 0
+ },
+ "d736_bw_coff_water_qty": {
+  "value": 0
+ },
+ "d737_bw_milk_time_qty": {
+  "value": 0
+ },
+ "d738_espressi_water_qty": {
+  "value": 0
+ },
+ "d739_espr_water_qty": {
+  "value": 0
+ },
+ "d740_id2_coffee_water_qty": {
+  "value": 0
+ },
+ "d741_tot_custom_b_bw": {
+  "value": 0
+ },
+ "d742_tot_bev_no_original": {
+  "value": 0
+ },
+ "d743_tot_bev_profile_std_p1": {
+  "value": 0
+ },
+ "d744_tot_bev_profile_other": {
+  "value": 0
+ },
+ "d745_profile_set": {
+  "value": 0
+ },
+ "d746_tot_bev_bBwNoMySize": {
+  "value": 0
+ },
+ "d747_bev_abort_cnt": {
+  "value": 0
+ },
+ "d748_bev_2x_cnt": {
+  "value": 0
+ },
+ "d820_water_heaterCalcRelQty": {
+  "value": 2966060
+ },
+ "d821_water_steamCalcRelQty": {
+  "value": 349860
+ },
+ "d822_water_heaterCalcAbsQty": {
+  "value": 10788040
+ },
+ "d823_water_steamCalcAbsQty": {
+  "value": 8599040
+ },
+ "d824_water_misuseCalcAbsQty": {
+  "value": 1071160
+ },
+ "d825_descale_status": {
+  "value": 0
+ },
+ "d826_last_4_water_calc_qty": {
+  "value": 3289915
+ },
+ "d827_last_4_calc_thrshld": {
+  "value": 3289650
+ },
+ "d828_gen_water_cnt_1": {
+  "value": 0
+ },
+ "d829_gen_water_cnt_2": {
+  "value": 0
+ },
+ "d830_gen_water_cnt_3": {
+  "value": 0
+ },
+ "d831_gen_water_cnt_4": {
+  "value": 0
+ },
+ "d832_gen_water_cnt_5": {
+  "value": 0
+ },
+ "d833_gen_water_cnt_6": {
+  "value": 0
+ },
+ "d834_gen_water_cnt_7": {
+  "value": 0
+ },
+ "d835_gen_water_cnt_8": {
+  "value": 0
+ },
+ "data_request": {
+  "value": "DQap8AHXwGnoxe4="
+ },
+ "data_response": {
+  "value": "0Aep8AEAOzxp6MXw"
+ },
+ "device_connected": {
+  "value": "1776862694"
+ },
+ "software_version": {
+  "value": "Millcore_demo 2.0.0 Jun 18 2020 15:41:06"
+ }
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,665 @@
+"""Unit tests for the machine-derived beverage catalogue (catalog.py).
+
+Anchored on ``fixtures/soul_properties.json``: a real 312-property dump from a
+reference PrimaDonna Soul (DL-millcore), anonymised - the serial and every
+user-entered name (profiles, custom recipes, beans) were overwritten with
+placeholders and their CRCs recomputed, so the file carries no device or
+household identifiers. Every count below was measured against that dump; they
+are pinned deliberately, so a future parser edit that quietly changes what the
+integration believes the machine can make fails here instead of in someone's
+kitchen.
+
+Loads only the dependency-free modules, like test_counters.py, so the suite runs
+with plain pytest and no Home Assistant installed.
+"""
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PKG_DIR = Path(__file__).resolve().parents[1] / "custom_components" / "delonghi_coffeelink"
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "soul_properties.json"
+
+if "delonghi_coffeelink" not in sys.modules:
+    _pkg = types.ModuleType("delonghi_coffeelink")
+    _pkg.__path__ = [str(PKG_DIR)]
+    sys.modules["delonghi_coffeelink"] = _pkg
+
+
+def _load(modname: str, filename: str):
+    full = f"delonghi_coffeelink.{modname}"
+    spec = importlib.util.spec_from_file_location(full, PKG_DIR / filename)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[full] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_load("const", "const.py")
+cb = _load("command_builder", "command_builder.py")
+catalog = _load("catalog", "catalog.py")
+
+
+@pytest.fixture(scope="module")
+def props() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def cat(props: dict) -> dict:
+    return catalog.build_catalog(props)
+
+
+def _blob(family: bytes, payload: bytes, *, trailer: bytes = b"") -> str:
+    """Build a well-formed base64 blob, CRC included, for synthetic cases."""
+    frame = bytes([catalog.BLOB_PREFIX, 0]) + family + payload
+    frame = bytes([catalog.BLOB_PREFIX, len(frame) + 1]) + family + payload
+    frame += cb.crc16_aug_ccitt(frame).to_bytes(2, "big")
+    return base64.b64encode(frame + trailer).decode("ascii")
+
+
+# --- the dump, as the machine actually published it ------------------------ #
+
+
+def test_family_census_matches_the_reference_machine(cat: dict):
+    """Every recipe-bearing family, counted. These numbers are the machine's."""
+    families = cat["stats"]["families"]
+    assert families["factory_descriptor"] == 28
+    assert families["profile_recipe"] == 140  # 28 ids x 5 profiles
+    assert families["menu_order"] == 5  # one ordered menu per profile
+    assert families["profile_names"] == 2
+    assert families["custom_names"] == 2
+    assert families["bean_names"] == 7
+
+
+def test_every_readable_blob_passes_crc(cat: dict):
+    """163 complete blobs, 163 valid checksums - the data is machine-authored."""
+    stats = cat["stats"]
+    assert stats["blobs"] == 194
+    assert stats["crc_ok"] == 163
+    assert stats["crc_failed"] == 0
+    assert stats["truncated"] == 31
+
+
+def test_every_payload_parses_with_no_leftover_bytes(cat: dict):
+    """One TLV rule consumes all 140 recipe payloads and all readable descriptors.
+
+    A leftover byte would mean the grammar does not fit, which is exactly the
+    input that could build a wrong brew command - so it is counted, and must be
+    zero.
+    """
+    assert cat["stats"]["unparsed_payloads"] == 0
+
+
+def test_length_gate_accepts_a_trailing_timestamp(props: dict):
+    """``declared <= len(raw)``, never ``==``.
+
+    The machine appends a 4-byte timestamp to its live channels. A strict
+    equality would misgrade ``data_response`` - a completed, CRC-valid
+    request/response round trip - as truncated garbage.
+    """
+    blob = catalog.decode_blob(props["data_response"]["value"])
+    assert blob is not None
+    assert blob["truncated"] is False
+    assert blob["crc_valid"] is True
+    assert len(blob["trailer"]) == 4
+
+
+# --- refusing to guess ----------------------------------------------------- #
+
+
+def test_a_truncated_descriptor_is_unreadable_never_absent(cat: dict):
+    """A cut blob still proves the drink exists; only its ranges are unknown.
+
+    20 of the 28 factory descriptors are truncated in this dump (a dump-tool
+    width limit, not a machine limitation). Espresso is one of them: it must
+    stay declared, with no invented range.
+    """
+    truncated = [i for i, item in cat["beverages"].items() if item["descriptor_truncated"]]
+    assert len(truncated) == 20
+    espresso = cat["beverages"][0x01]
+    assert espresso["declared"] is True
+    assert espresso["ranges"] == {}
+
+
+def test_off_default_is_none_when_the_factory_default_is_unknown(cat: dict):
+    """Unknown must never read as "the user changed nothing".
+
+    Espresso reads 48 ml on profiles 1/4/5 and 40 ml on 2/3, but its factory
+    descriptor is truncated, so whether 48 is a customisation cannot be known.
+    That is reported as ``profiles_differ``, a weaker and different signal, and
+    ``off_default`` stays ``None``.
+    """
+    espresso = cat["beverages"][0x01]
+    assert espresso["off_default"] is None
+    assert espresso["profiles_differ"] is True
+    volumes = {params[catalog.TAG_COFFEE_ML] for params in espresso["profiles"].values()}
+    assert volumes == {40, 48}
+    unknown = [i for i, item in cat["beverages"].items() if item["off_default"] is None]
+    assert len(unknown) == 20
+
+
+def test_factory_ranges_are_read_not_guessed(cat: dict):
+    """The machine publishes the editable ranges a CMS would have to supply."""
+    assert cat["beverages"][0x10]["ranges"][catalog.TAG_WATER_ML] == (20, 250, 420)
+    assert cat["beverages"][0x0C]["ranges"][catalog.TAG_MILK] == (50, 360, 1080)
+    assert cat["beverages"][0x17]["ranges"][catalog.TAG_CUP_COUNT] == (0, 0, 5)
+    with_ranges = [i for i, item in cat["beverages"].items() if item["ranges"]]
+    assert len(with_ranges) == 8  # the 8 descriptors this dump did not truncate
+
+
+def test_a_corrupted_blob_is_dropped_not_parsed():
+    """One flipped byte fails the CRC, and the blob is refused whole."""
+    payload = bytes([0x10, catalog.TAG_WATER_ML, 0, 20, 0, 250, 1, 164])
+    raw = bytearray(base64.b64decode(_blob(catalog.FAMILY_DESCRIPTOR, payload)))
+    raw[5] ^= 0xFF
+    corrupted = base64.b64encode(bytes(raw)).decode()
+    assert catalog.decode_blob(corrupted)["crc_valid"] is False
+    cat = catalog.build_catalog({"d001_rec_espresso": {"value": corrupted}})
+    assert cat["stats"]["crc_failed"] == 1
+    assert cat["beverages"] == {}
+
+
+def test_tlv_refuses_a_partial_walk():
+    """A trailing byte returns None, never a half-parsed parameter set."""
+    assert catalog.parse_tlv(bytes([0x1B, 0x02])) == {0x1B: 2}
+    assert catalog.parse_tlv(bytes([0x01, 0x00, 0x30])) == {0x01: 0x30}
+    assert catalog.parse_tlv(bytes([0x1B, 0x02, 0x01])) is None  # wide tag, one byte short
+    assert catalog.parse_tlv(bytes([0x1B])) is None
+
+
+def test_triples_refuse_a_partial_walk():
+    """Same refusal for the min/default/max form."""
+    assert catalog.parse_triples(bytes([0x1B, 0, 1, 4])) == {0x1B: (0, 1, 4)}
+    wide = bytes([0x0F, 0, 20, 0, 250, 1, 164])
+    assert catalog.parse_triples(wide) == {0x0F: (20, 250, 420)}
+    assert catalog.parse_triples(bytes([0x0F, 0, 20, 0, 250, 1])) is None
+
+
+# --- what the machine says it can make ------------------------------------- #
+
+
+def test_the_menu_is_the_machines_own_ordered_list(cat: dict):
+    """5 profiles, 18 drinks each, identical set, different order per profile."""
+    menu = cat["menu"]
+    assert sorted(menu) == [1, 2, 3, 4, 5]
+    assert {len(ids) for ids in menu.values()} == {18}
+    sets = [frozenset(ids) for ids in menu.values()]
+    assert len(set(sets)) == 1, "all profiles offer the same drinks"
+    assert len({tuple(ids) for ids in menu.values()}) > 1, "but not in the same order"
+
+
+def test_three_drinks_are_declared_but_not_on_the_menu(cat: dict):
+    """The integration currently offers 21 buttons; this machine lists 18.
+
+    long_black, mug_to_go and brew_over_ice have recipe slots from the shared
+    firmware template and lifetime counters stuck at 0, but the machine never
+    lists them - so three of the buttons we ship for it are fiction.
+    """
+    off_menu = {i for i, item in cat["beverages"].items() if item["on_menu"] is False}
+    assert off_menu == {0x19, 0x1A, 0x1B}
+    on_menu = [i for i, item in cat["beverages"].items() if item["on_menu"] is True]
+    assert len(on_menu) == 18
+
+
+def test_on_menu_is_unknown_for_slots_the_menu_does_not_enumerate(cat: dict):
+    """``on_menu`` must never be an existence test for custom or bean slots.
+
+    The menu blob lists only built-in ids, so reading "absent from the menu" as
+    "does not exist" would suppress precisely the entries discovery is for.
+    """
+    for bev_id in list(catalog.CUSTOM_SLOT_IDS) + [0xC8]:
+        item = cat["beverages"].get(bev_id)
+        if item is not None:
+            assert item["on_menu"] is None
+
+
+def test_custom_slots_are_found_and_reported_as_unprogrammed(cat: dict):
+    """Six saved-recipe slots exist; none is programmed on this machine.
+
+    The machine's own "not defined yet" state (no quantity, 0xff intensity) is
+    detectable, which is what lets a UI hide an empty slot instead of offering a
+    button that brews nothing.
+    """
+    custom = {i: item for i, item in cat["beverages"].items() if item["kind"] == "custom"}
+    assert set(custom) == set(catalog.CUSTOM_SLOT_IDS)
+    assert all(item["defined"] is False for item in custom.values())
+    assert all(len(item["profiles"]) == 5 for item in custom.values())
+
+
+def test_a_programmed_custom_slot_is_reported_as_defined():
+    """The same detection, the other way round."""
+    payload = bytes([1, 0xE6, catalog.TAG_COFFEE_ML, 0x00, 0x50, catalog.TAG_INTENSITY, 3])
+    blob = _blob(catalog.FAMILY_PROFILE_RECIPE, payload)
+    cat = catalog.build_catalog({"d200_1_cstm_recipe_01": {"value": blob}})
+    assert cat["beverages"][0xE6]["defined"] is True
+
+
+def test_the_bean_system_drink_is_discovered(cat: dict):
+    """0xc8 is a real brewable entry the hardcoded beverage list has never had."""
+    bean = cat["beverages"][0xC8]
+    assert bean["kind"] == "bean_system"
+    assert bean["declared"] is True
+    assert bean["ranges"], "its factory descriptor is readable in this dump"
+
+
+def test_builtin_ids_match_the_shipped_beverage_list(cat: dict):
+    """21 built-in ids - the 2x_espresso trap, counted the hard way.
+
+    A regex like ``_rec_[a-z]`` silently drops ``2x_espresso`` because the drink
+    key starts with a digit, giving 20. Parsing by blob family cannot make that
+    mistake: the id is a byte.
+    """
+    builtin = {i for i, item in cat["beverages"].items() if item["kind"] == "builtin"}
+    assert len(builtin) == 21
+    assert 0x04 in builtin
+
+
+# --- parsing by family, not by name ---------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "d022_beansystem_1",  # the bean-system descriptor
+        "d160_1_bs_recipe_01",  # a per-profile bean-system recipe
+        "d200_1_cstm_recipe_01",  # a saved-recipe slot
+        "d036_recipe_custom_name_1_3",  # the slot names
+    ],
+)
+def test_the_substring_filter_misses_what_family_parsing_finds(props: dict, name: str):
+    """These four shapes are exactly what the old ``"_rec_" in name`` filter lost.
+
+    Every one of them is a custom or bean-system recipe - the entries a
+    catalogue exists to discover.
+    """
+    assert "_rec_" not in name, "the legacy filter would skip it"
+    assert name in dict(catalog.iter_blobs(props)), "the family switch finds it"
+
+
+def test_the_legacy_name_filter_undercounts_the_recipes(props: dict):
+    """137 by name, 194 blobs by family - measured on the reference machine."""
+    by_name = [n for n in props if "_rec_" in n]
+    assert len(by_name) == 137
+    assert len(dict(catalog.iter_blobs(props))) == 194
+
+
+def test_the_dump_diagnostic_now_selects_by_family(props: dict):
+    """``recipe_dump_lines`` must surface the custom and bean-system recipes."""
+    rendered = "\n".join(cb.recipe_dump_lines(props))
+    assert "d022_beansystem_1 [family b0f0]" in rendered
+    assert "d200_1_cstm_recipe_01 [family a6f0]" in rendered
+    assert "d261_1_rec_priority [family a8f0]" in rendered
+    assert len(cb.recipe_dump_lines(props)) == 184
+
+
+def test_the_dump_never_publishes_an_identifier(props: dict):
+    """This log is the block the README tells users to paste into an issue.
+
+    The machine wraps its serial number, its settings PIN, the monitor blob and
+    the response channel in the same ``0xd0`` envelope as its recipes, so
+    selecting on the prefix alone would put a serial in every bug report. Only
+    the six catalogue families are rendered.
+    """
+    rendered = "\n".join(cb.recipe_dump_lines(props))
+    for excluded in (
+        "d270_serialnumber",  # family a10f - the machine's serial, in ASCII
+        "d280_mchn_sett_pin",  # family 950f
+        "d302_monitor",  # family 750f
+        "data_response",  # family a9f0
+    ):
+        assert excluded not in rendered, f"{excluded} must never reach a public log"
+
+
+def test_the_dump_redacts_names_the_household_typed_in(props: dict):
+    """Profile names are first names. Their structure is useful; their text is not."""
+    rendered = "\n".join(cb.recipe_dump_lines(props))
+    assert "d034_profiles_1_3 [family a4f0]" in rendered, "the blob is still dumped"
+    assert "bytes of name redacted>" in rendered
+    # The fixture's placeholders stand in for real names - none may be rendered.
+    for placeholder in ("Profile 2", "Slot 2", "Bean 1"):
+        encoded = placeholder.encode("utf-16-be").hex(" ")
+        assert encoded not in rendered
+
+
+def test_property_names_are_labels_only(props: dict):
+    """The blob header decides what a datapoint is - the name never does.
+
+    Renaming every property Eletta-style (the same drinks are ``d059_rec_1_*``
+    there, numbers shifted by 20) must change nothing about what is discovered.
+    """
+    renamed = {f"zz{i:03d}_whatever": prop for i, prop in enumerate(props.values())}
+
+    def _without_labels(cat: dict) -> dict:
+        # source_properties is the one field that is *meant* to carry the names.
+        return {
+            bev_id: {k: v for k, v in item.items() if k != "source_properties"}
+            for bev_id, item in cat["beverages"].items()
+        }
+
+    assert _without_labels(catalog.build_catalog(renamed)) == _without_labels(
+        catalog.build_catalog(props)
+    )
+
+
+# --- degrading honestly ---------------------------------------------------- #
+
+
+def test_no_properties_yields_an_empty_source_not_an_empty_catalogue():
+    cat = catalog.build_catalog({})
+    assert cat["source"] == "empty"
+    assert cat["beverages"] == {}
+    assert "no machine catalogue" in catalog.catalog_summary(cat)
+    assert "no machine catalogue" in catalog.catalog_summary(None)
+
+
+@pytest.mark.parametrize("value", [None, "", "   ", 42, "not base64 !!", "QUJD", {"a": 1}])
+def test_non_blob_values_are_ignored_without_raising(value):
+    assert catalog.decode_blob(value) is None
+
+
+def test_decode_text_reads_the_first_slot_only():
+    """Names are UTF-16BE in NUL-padded slots; only slot 1 aligns reliably."""
+    payload = "Perso 1".encode("utf-16-be") + b"\x00\x00" + "Perso 2".encode("utf-16-be")
+    assert catalog.decode_text(payload) == "Perso 1"
+    assert catalog.decode_text(b"\x00\x00\x00\x00") is None
+    assert catalog.decode_text(b"") is None
+
+
+def test_summary_reports_what_was_unreadable(cat: dict):
+    """The diagnostic line must show the truncation, not hide it."""
+    summary = catalog.catalog_summary(cat)
+    assert "28 beverage ids" in summary
+    assert "18 on the machine menu" in summary
+    assert "truncated=31" in summary
+
+
+# --- the learn gate -------------------------------------------------------- #
+
+
+def test_catalog_beverage_ids_lists_every_declared_id(cat: dict):
+    ids = catalog.catalog_beverage_ids(cat)
+    assert 0xE6 in ids, "a saved-recipe slot"
+    assert 0xC8 in ids, "the bean-system drink"
+    assert 0x01 in ids
+    assert catalog.catalog_beverage_ids(None) == set()
+    assert catalog.catalog_beverage_ids({}) == set()
+
+
+def test_a_saved_recipe_brewed_from_the_app_is_now_learnable(cat: dict):
+    """The bug this fixes: "Perso 1" pressed in the official app was discarded.
+
+    ``0xe6`` is not in the hardcoded beverage list, so the captured frame - the
+    only way to ever reproduce that drink - was dropped in silence.
+    """
+    frame = cb.encode_command(cb.build_beverage_command(0xE6, 0x01))
+    decoded = cb.decode_command(frame)
+    assert decoded["crc_valid"] is True
+    assert cb.learnable_beverage_id(decoded) is None, "the old gate dropped it"
+    assert cb.learnable_beverage_id(decoded, catalog.catalog_beverage_ids(cat)) == 0xE6
+
+
+def test_widening_the_gate_still_refuses_an_id_no_one_declares(cat: dict):
+    frame = cb.encode_command(cb.build_beverage_command(0x7F, 0x01))
+    decoded = cb.decode_command(frame)
+    assert cb.learnable_beverage_id(decoded, catalog.catalog_beverage_ids(cat)) is None
+
+
+def test_widening_the_gate_does_not_weaken_the_checksum_rule(cat: dict):
+    """A corrupt frame stays unlearnable however many ids the machine declares."""
+    raw = bytearray(base64.b64decode(cb.encode_command(cb.build_beverage_command(0xE6, 0x01))))
+    raw[4] = 0xE7  # id changed after the CRC was computed
+    decoded = cb.decode_command(base64.b64encode(bytes(raw)).decode())
+    assert decoded["crc_valid"] is False
+    assert cb.learnable_beverage_id(decoded, catalog.catalog_beverage_ids(cat)) is None
+
+
+def test_a_blob_too_short_for_its_own_header_is_refused():
+    """A frame can pass the CRC and still be too short to index.
+
+    ``d0 05 b0 f0 <crc>`` is a well-formed, checksum-valid descriptor with no
+    beverage id in it. Reading ``payload[0]`` there would raise and take the
+    whole catalogue down with it, so the shape is checked before any indexing.
+    """
+    for family in (
+        catalog.FAMILY_DESCRIPTOR,
+        catalog.FAMILY_PROFILE_RECIPE,
+        catalog.FAMILY_MENU,
+        catalog.FAMILY_BEAN_NAMES,
+    ):
+        blob = _blob(family, b"")
+        assert catalog.decode_blob(blob)["crc_valid"] is True
+        cat = catalog.build_catalog({"d001_rec_espresso": {"value": blob}})
+        assert cat["stats"]["short_payloads"] == 1
+        assert cat["beverages"] == {}
+
+
+def test_a_menu_entry_without_a_recipe_is_listed_but_not_declared():
+    """On the menu, yet no descriptor: exists for the user, not learnable."""
+    blob = _blob(catalog.FAMILY_MENU, bytes([1, 0xC8, 0x07]))
+    cat = catalog.build_catalog({"d261_1_rec_priority": {"value": blob}})
+    entry = cat["beverages"][0x07]
+    assert entry["on_menu"] is True
+    assert entry["declared"] is False
+    assert catalog.catalog_beverage_ids(cat) == set()
+
+
+def test_the_fixture_carries_no_identifiers(props: dict):
+    """The fixture ships in a public repo - it must hold nothing personal.
+
+    Every blob is decoded and searched, both as UTF-16BE (how the machine stores
+    names) and as Latin-1 (how it stores the serial). Only the placeholders
+    written by ``fixtures/anonymise_dump.py`` may survive.
+    """
+    import re
+
+    allowed = re.compile(r"^(Profile|Slot|Bean) \d+$|^X*0*$")
+    found: list[tuple[str, str]] = []
+    for name in props:
+        raw = catalog._b64_bytes(props[name].get("value"))
+        if not raw:
+            continue
+        for encoding in ("utf-16-be", "latin-1"):
+            for match in re.finditer(
+                r"[A-Za-z][A-Za-z0-9 ._/()-]{3,}", raw.decode(encoding, "ignore")
+            ):
+                if not allowed.match(match.group().strip()):
+                    found.append((name, match.group()))
+    assert not found, f"identifying text survived anonymisation: {found}"
+
+    # Not every identifier is text. The Wi-Fi MAC is three plain integers, and a
+    # scan that only decodes the base64 strings walks straight past it.
+    for mac_part in ("d521_radio_mac_addr0", "d522_radio_mac_addr1", "d523_radio_mac_addr2"):
+        assert props[mac_part]["value"] == 0, f"{mac_part} still holds the real MAC"
+
+
+def test_the_fixture_is_the_real_thing(props: dict):
+    """Anonymising must not have turned the dump into synthetic data.
+
+    The rewritten name blobs get fresh CRCs; everything the parser reasons about
+    - recipes, descriptors, menus - is the machine's own untouched bytes.
+    """
+    assert len(props) == 312
+    assert props["software_version"]["value"].startswith("Millcore_demo")
+    assert catalog.build_catalog(props)["stats"]["crc_failed"] == 0
+
+
+# --- the derived signals, pinned to real values ---------------------------- #
+
+
+def test_off_default_reports_what_the_user_actually_changed(cat: dict):
+    """Tea is customised, Coffee is not - and the parser can tell, exactly.
+
+    Both have a readable factory descriptor, so the comparison is available for
+    both. Tea sits off its factory default on water volume (0x0f), temperature
+    (0x1b) and 0x0d; Coffee sits on the default for every parameter it has.
+    Asserting only that the dict exists let both branches rot.
+    """
+    tea = cat["beverages"][0x16]["off_default"]
+    assert tea == {0x19: False, catalog.TAG_WATER_ML: True, catalog.TAG_TEMPERATURE: True, 0x0D: True}
+    coffee = cat["beverages"][0x02]["off_default"]
+    assert coffee == {
+        0x19: False,
+        catalog.TAG_TEMPERATURE: False,
+        catalog.TAG_COFFEE_ML: False,
+        catalog.TAG_INTENSITY: False,
+        0x04: False,
+    }
+    assert set(coffee.values()) == {False}, "untouched means every tag False, not an empty dict"
+
+
+def test_profiles_differ_is_asserted_both_ways(cat: dict):
+    """Espresso differs across profiles; Coffee does not."""
+    assert cat["beverages"][0x01]["profiles_differ"] is True
+    assert cat["beverages"][0x02]["profiles_differ"] is False
+
+    same = {
+        f"d0{39 + i}_{p}_rec_espresso": {
+            "value": _blob(
+                catalog.FAMILY_PROFILE_RECIPE, bytes([p, 0x01, catalog.TAG_COFFEE_ML, 0x00, 0x28])
+            )
+        }
+        for i, p in enumerate((1, 2, 3))
+    }
+    assert catalog.build_catalog(same)["beverages"][0x01]["profiles_differ"] is False
+
+
+def test_on_menu_is_unknown_when_no_menu_blob_was_read():
+    """No menu blob means no opinion - never "not on the menu"."""
+    payload = bytes([0x10, catalog.TAG_WATER_ML, 0, 20, 0, 250, 1, 164])
+    cat = catalog.build_catalog({"d015_rec_hot_water": {"value": _blob(catalog.FAMILY_DESCRIPTOR, payload)}})
+    assert cat["beverages"][0x10]["on_menu"] is None
+    assert cat["menu"] == {}
+    assert "0 on the machine menu" not in catalog.catalog_summary(cat)
+
+
+def test_an_unparsable_payload_is_counted_and_never_half_parsed():
+    """A leftover byte must leave the values absent, with the drink still declared."""
+    cat = catalog.build_catalog(
+        {
+            # a wide tag with only one of its two value bytes
+            "d040_1_rec_regular": {
+                "value": _blob(
+                    catalog.FAMILY_PROFILE_RECIPE, bytes([1, 0x02, catalog.TAG_COFFEE_ML, 0x00])
+                )
+            },
+            # a triple missing its last value
+            "d015_rec_hot_water": {
+                "value": _blob(catalog.FAMILY_DESCRIPTOR, bytes([0x10, catalog.TAG_WATER_ML, 0, 20, 0]))
+            },
+        }
+    )
+    assert cat["stats"]["unparsed_payloads"] == 2
+    assert cat["beverages"][0x02]["profiles"] == {}
+    assert cat["beverages"][0x10]["declared"] is True
+    assert cat["beverages"][0x10]["ranges"] == {}
+
+
+def test_name_blobs_are_filed_by_family_and_slot():
+    """The three text families each land in their own bucket, keyed by slot.
+
+    The reference dump truncates every name blob, so this is the only coverage
+    the ``names`` bucket has - without it the whole feature could be deleted and
+    the suite would stay green.
+    """
+    cat = catalog.build_catalog(
+        {
+            "d034_profiles_1_3": {
+                "value": _blob(
+                    catalog.FAMILY_PROFILE_NAMES, bytes([1, 3]) + "Alice".encode("utf-16-be")
+                )
+            },
+            "d036_recipe_custom_name_1_3": {
+                "value": _blob(
+                    catalog.FAMILY_CUSTOM_NAMES, bytes([2, 3]) + "Perso 1".encode("utf-16-be")
+                )
+            },
+            "d250_beansystem_0": {
+                "value": _blob(
+                    catalog.FAMILY_BEAN_NAMES, bytes([0, 0]) + "Kimbo".encode("utf-16-be")
+                )
+            },
+        }
+    )
+    assert cat["names"] == {
+        "profiles": {1: "Alice"},
+        "custom": {2: "Perso 1"},
+        "beans": {0: "Kimbo"},
+    }
+
+
+def test_summary_reports_every_counter(cat: dict):
+    """Spot-checking three substrings let the other five counters mutate freely."""
+    assert catalog.catalog_summary(cat) == (
+        "28 beverage ids (18 on the machine menu, 3 declared but off-menu, "
+        "6 custom slots of which 0 programmed), 8 with factory min/default/max "
+        "ranges, 5 profile menus | blobs=194 crc_ok=163 crc_failed=0 "
+        "truncated=31 unparsed=0 short=0"
+    )
+
+
+# --- change detection ------------------------------------------------------ #
+
+
+def test_the_fingerprint_ignores_the_live_channels(props: dict):
+    """The monitor and response datapoints wear the same envelope as a recipe.
+
+    They also carry a fresh timestamp on nearly every poll. Including them would
+    change the key constantly and re-parse the catalogue for nothing.
+    """
+    key = catalog.catalog_fingerprint(props)
+    names = [name for name, _ in key]
+    assert len(key) == 184, "the six catalogue families, nothing else"
+    for live in ("d302_monitor", "data_response", "d270_serialnumber", "d280_mchn_sett_pin"):
+        assert live not in names
+
+    moved = dict(props)
+    moved["d302_monitor"] = {"value": _blob(b"\x75\x0f", bytes([1, 2, 3]))}
+    assert catalog.catalog_fingerprint(moved) == key
+
+
+def test_the_fingerprint_sees_a_recipe_change(props: dict):
+    """The direction that must never fail: an edited recipe changes the key."""
+    key = catalog.catalog_fingerprint(props)
+    edited = dict(props)
+    edited["d039_1_rec_espresso"] = {
+        "value": _blob(
+            catalog.FAMILY_PROFILE_RECIPE, bytes([1, 0x01, catalog.TAG_COFFEE_ML, 0x00, 0x3C])
+        )
+    }
+    assert catalog.catalog_fingerprint(edited) != key
+
+    # ...and so does a recipe disappearing entirely.
+    removed = {k: v for k, v in props.items() if k != "d039_1_rec_espresso"}
+    assert catalog.catalog_fingerprint(removed) != key
+
+
+def test_the_fingerprint_normalises_whitespace_like_the_parser(props: dict):
+    """Ayla wraps string datapoints in whitespace; the parser strips it.
+
+    A key that compared raw values would report a change the parser cannot see,
+    or miss one it can - a change-detector out of step with the thing it guards
+    is how a cache freezes without anyone noticing.
+    """
+    key = catalog.catalog_fingerprint(props)
+    padded = {
+        name: {"value": f"\n {prop['value']} \n" if isinstance(prop["value"], str) else prop["value"]}
+        for name, prop in props.items()
+    }
+    assert catalog.catalog_fingerprint(padded) == key
+    assert catalog.build_catalog(padded)["beverages"] == catalog.build_catalog(props)["beverages"]
+
+
+def test_blob_family_reads_the_family_without_a_full_decode(props: dict):
+    assert catalog.blob_family(props["d039_1_rec_espresso"]["value"]) == catalog.FAMILY_PROFILE_RECIPE
+    assert catalog.blob_family(props["d261_1_rec_priority"]["value"]) == catalog.FAMILY_MENU
+    assert catalog.blob_family(props["d270_serialnumber"]["value"]) == b"\xa1\x0f"
+    for not_a_blob in (None, "", "AA==", "not base64 !!", 42, "QUJDRA=="):
+        assert catalog.blob_family(not_a_blob) is None

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -816,3 +816,161 @@ def test_the_last_connected_sensor_is_registered_on_every_machine():
     assert "entities.append(DelonghiLastConnectedSensor(coord))" in source
     assert 'super().__init__(coord, "last_connected", "mdi:clock-outline")' in source
     assert "self.coordinator.device.connected_at" in source
+
+
+# --- machine beverage catalogue (catalog.py, wired into the poll) ------------
+
+catalog = _load("catalog", "catalog.py")
+
+
+def _blob(family: bytes, payload: bytes) -> str:
+    """A well-formed machine blob: d0 <len> <family> <payload> <crc16>."""
+    body = family + payload
+    frame = bytes([const.CMD_RESPONSE_PREFIX, len(body) + 3]) + body
+    frame += cb.crc16_aug_ccitt(frame).to_bytes(2, "big")
+    return base64.b64encode(frame).decode("ascii")
+
+
+#: A machine declaring one custom slot (0xe6) with a per-profile recipe for it.
+SLOT_PROPS = {
+    "d028_rec_custom_1": {
+        "value": _blob(
+            catalog.FAMILY_DESCRIPTOR,
+            bytes([0xE6, catalog.TAG_COFFEE_ML, 0, 20, 0, 80, 0, 120]),
+        )
+    },
+    "d200_1_cstm_recipe_01": {
+        "value": _blob(
+            catalog.FAMILY_PROFILE_RECIPE,
+            bytes([1, 0xE6, catalog.TAG_COFFEE_ML, 0x00, 0x50, catalog.TAG_INTENSITY, 3]),
+        )
+    },
+}
+
+
+def _slot_frame(bev_id: int = 0xE6) -> str:
+    """A frame the *app* would send for a saved recipe: its own recipe bytes.
+
+    Not ``build_beverage_command`` defaults - those are bytes this integration
+    could have produced itself, which the sniffer refuses to learn on purpose
+    (it would replace the "teach me from the app" prompt with a frame the
+    machine ignores).
+    """
+    return cb.encode_command(
+        cb.build_eletta_beverage_command(bev_id, 0x03, bytes.fromhex("01 00 50 02 03"))
+    )
+
+
+def test_a_poll_builds_the_catalogue_from_the_properties_it_already_has():
+    """No extra request: discovery is a pure function of the poll's own result."""
+    client = _PollingClient(props=dict(SLOT_PROPS))
+    coord = _coord("DL-millcore", client=client)
+    assert coord.catalog is None
+
+    asyncio.run(coord._async_update_data())
+
+    assert coord.catalog is not None
+    assert 0xE6 in coord.catalog["beverages"]
+    assert coord.catalog["beverages"][0xE6]["defined"] is True
+    assert client.writes == [], "reading the catalogue must never write to the machine"
+
+
+def test_an_unchanged_poll_does_not_rebuild_the_catalogue():
+    """The fingerprint is what keeps the parse off the polls where nothing moved."""
+    client = _PollingClient(props=dict(SLOT_PROPS))
+    coord = _coord("DL-millcore", client=client)
+    asyncio.run(coord._async_update_data())
+    first = coord.catalog
+
+    asyncio.run(coord._async_update_data())
+    assert coord.catalog is first, "same bytes must not re-parse"
+
+    # A recipe edited on the machine must be picked up, though - a cache that
+    # cannot see a change is the failure mode this project keeps being bitten by.
+    client.props = dict(SLOT_PROPS)
+    client.props["d200_1_cstm_recipe_01"] = {
+        "value": _blob(
+            catalog.FAMILY_PROFILE_RECIPE,
+            bytes([1, 0xE6, catalog.TAG_COFFEE_ML, 0x00, 0x64, catalog.TAG_INTENSITY, 3]),
+        )
+    }
+    asyncio.run(coord._async_update_data())
+    assert coord.catalog is not first
+    assert coord.catalog["beverages"][0xE6]["profiles"][1][catalog.TAG_COFFEE_ML] == 0x64
+
+
+def test_a_poll_with_no_readable_blobs_keeps_the_catalogue_it_had():
+    """A blank poll must never look like a machine that lost its recipes."""
+    client = _PollingClient(props=dict(SLOT_PROPS))
+    coord = _coord("DL-millcore", client=client)
+    asyncio.run(coord._async_update_data())
+    known = coord.catalog
+
+    client.props = {"software_version": {"value": "Millcore_demo 2.0.0"}}
+    asyncio.run(coord._async_update_data())
+    assert coord.catalog is known
+
+
+def test_a_broken_catalogue_never_breaks_the_poll(monkeypatch):
+    """Diagnostic-grade, like the monitor decode: the poll must still return."""
+    client = _PollingClient(props=dict(SLOT_PROPS))
+    coord = _coord("DL-millcore", client=client)
+    monkeypatch.setattr(
+        coordinator, "build_catalog", lambda props: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    props = asyncio.run(coord._async_update_data())
+    assert props == SLOT_PROPS
+    assert coord.catalog is None
+
+
+def test_a_saved_recipe_frame_is_learned_because_the_machine_declares_it():
+    """The bug: pressing "Perso 1" in the official app had its frame discarded.
+
+    0xe6 is not in the hardcoded beverage list, so the only bytes that could
+    ever reproduce that drink were dropped in silence. The catalogue built from
+    the same poll is what makes the frame learnable.
+    """
+    frame = _slot_frame()
+    coord = _coord("DL-striker-cb")
+    _capture(coord, frame)
+    assert coord.learned_start_frames == {}, "without a catalogue, still dropped"
+
+    coord = _coord("DL-striker-cb")
+    coord.catalog = catalog.build_catalog(SLOT_PROPS)
+    _capture(coord, frame)
+    assert coord.learned_start_frames == {0xE6: frame}
+    assert coord._store.saves == 1, "and it is persisted, so it survives a restart"
+
+
+def test_the_catalogue_is_built_before_the_frame_is_sniffed():
+    """Ordering matters: a slot brewed on this very poll must be learnable now.
+
+    If _update_catalog ran after _sniff_app_traffic, the first press of a saved
+    recipe would always be lost and only the second would stick.
+    """
+    frame = _slot_frame()
+    # Poll 1: the channel is seen for the first time (never a capture, by
+    # design) and the machine has not published the slot yet.
+    client = _PollingClient(
+        props={"app_data_request": {"value": "AA==", "data_updated_at": "t0"}}
+    )
+    coord = _coord("DL-striker-cb", client=client)
+    coord.command_property = "app_data_request"
+    asyncio.run(coord._async_update_data())
+    assert coord.catalog is None
+
+    # Poll 2 brings the slot declaration and the frame together. Build the
+    # catalogue after sniffing and this first press is lost.
+    client.props = dict(SLOT_PROPS)
+    client.props["app_data_request"] = {"value": frame, "data_updated_at": "t1"}
+    asyncio.run(coord._async_update_data())
+    assert coord.learned_start_frames == {0xE6: frame}
+
+
+def test_an_id_no_one_declares_is_still_refused():
+    """Widening the gate must not turn it into no gate at all."""
+    frame = _slot_frame(bev_id=0x7F)
+    coord = _coord("DL-striker-cb")
+    coord.catalog = catalog.build_catalog(SLOT_PROPS)
+    _capture(coord, frame)
+    assert coord.learned_start_frames == {}


### PR DESCRIPTION
## The machine has been publishing its own beverage catalogue all along

Every recipe datapoint the coordinator already polls is a self-describing blob:

```
d0 <len> <family 2B> [<profile 1B>] <bevid 1B> <TLV params...> <crc16>
```

`len` is the frame size minus the start byte, and the CRC is the **same CRC16 AUG-CCITT the command builder already implements** - so a blob can be *proved* intact before anything is derived from it.

Measured on the reference PrimaDonna Soul (`DL-millcore`, 312 properties):

| | |
|---|---|
| blobs found | **194** |
| complete, checksum valid | **163 / 163** |
| recipe payloads consumed with zero leftover bytes | **140 / 140** |
| parse cost | ~4 ms, behind a change key, **no new request** |

One TLV rule covers everything, no per-beverage special cases: tags `0x01`, `0x09`, `0x0f` carry a 16-bit big-endian value, every other tag 8 bits. In a factory descriptor the same tags carry a *triple* - `(min, default, max)`.

### What the machine turns out to publish

- **Which drinks it actually offers, and in what order, per profile.** 18 on this machine. The integration ships 21 buttons for it, so **three of them are fiction** - `long_black`, `mug_to_go` and `brew_over_ice` have recipe slots from the shared firmware template and lifetime counters stuck at 0, but the machine never lists them.
- **Every parameter of every drink on every profile** - espresso 48 ml on profiles 1/4/5, 40 ml on 2/3.
- **The editable ranges**, from the factory descriptors: hot water `20/250/420` ml, hot milk `50/360/1080`, coffee pot cup count `0/0/5`.
- **The six saved-recipe slots and the bean-system drink** - ids `0xe6`-`0xeb` and `0xc8`, none of which the hardcoded beverage list has ever had.
- The user-entered names.

Parsing is **by blob family, never by property name**: the Soul writes `d039_1_rec_espresso` where the Eletta writes `d059_rec_1_espresso`, with the numbers shifted by 20 for the same drink. The blob header is identical on both.

## Fixed: a drink you saved on the machine could never be learned

`learnable_beverage_id` accepted only the 21 hardcoded ids. Pressing **"Perso 1"** (`0xe6`-`0xeb`) or a bean-system drink (`0xc8`) in the official app had its captured frame **discarded in silence** - and on a learn-and-replay model that frame is the only way the integration could ever reproduce that drink.

The gate now also accepts the ids the machine itself declares. The checksum rule is unchanged: a corrupt frame is still never learned, and neither is one this integration could have produced itself.

## Fixed: the recipe dump missed exactly the recipes worth dumping

It selected by the substring `_rec_`, which caught 137 datapoints and skipped **all 30 saved-recipe blobs, all 5 bean-system recipes and `d022_beansystem_1`**. It now selects by blob family.

## ⚠️ Security: the dump must not publish identifiers

This one is worth reading even if you skim the rest.

The machine wraps its **serial number** (`d270`, family `a10f`), its **settings PIN** (`d280`, `950f`), the monitor blob and the command-response channel in the *same* `0xd0` envelope as its recipes. Selecting on that prefix alone would have put a serial in every bug report - and `README.md` asks users to paste this exact block into public GitHub issues.

Only the six catalogue families are rendered now, and the user-entered text of the three name families (**profile names are first names**) is replaced by a byte count, keeping the structure without the content. The old `_rec_` filter never reached any of them, so this is a regression this PR introduced and then closed before merge.

## Nothing is asserted beyond what the bytes support

A beverage button that lies is worse than one that is missing:

- a blob failing any gate (prefix, declared length, CRC) is **unreadable**, never **absent** - it never removes a drink from the catalogue;
- a TLV walk with a leftover byte is **refused whole**, never half-parsed - a partial parse is precisely the input that could build a wrong brew command;
- `off_default` is `None`, **not `False`**, wherever the factory descriptor is truncated. Cross-profile disagreement is reported separately, as `profiles_differ`, because it is the weaker signal;
- `on_menu` stays `None` for anything the menu blob does not enumerate, so it can never be used as an existence test against the very entries discovery exists to find;
- the length gate is `declared <= len(raw)`, not `==`: the machine appends a 4-byte timestamp to its live channels, and strict equality would misgrade `data_response` - a completed, CRC-valid round trip - as truncated garbage.

## No entities are created or removed

Deliberate. This PR reads, proves and reports. Entity work comes later, on top of a parser that has been in the field.

## Tests

**242 pass**, ruff clean.

`tests/fixtures/soul_properties.json` is a real 312-property dump, anonymised: the serial, the Wi-Fi MAC (**three plain integers** - a scan that only reads the base64 strings walks straight past it) and every user-entered name overwritten, with checksums recomputed so the fixture still exercises the CRC path exactly as the machine's own bytes would. `fixtures/anonymise_dump.py` reproduces it, and a test fails the day the fixture is refreshed without re-anonymising.

**14 deliberate mutations** of the parser and the coordinator wiring were each caught by the suite - among them the names offset, the CRC check, the length gate, the short-payload guard, the build-before-sniff ordering, and the change key in both directions.

Two bugs were found *by* writing those tests: a blob CRC-valid but too short for its own header crashed the whole parser on `payload[0]`, and the name blobs were read at `payload[1:]` instead of `payload[2:]` - a one-byte shift that stayed invisible because every name blob in the reference dump is truncated, so the branch was dead.

## Not in this PR

- The recipe-datapoint → brew-command transform. It is proven real (espresso is a direct hit on Eletta; the hot-water quantity byte `0xfa` = 250 ml matches verbatim on the Soul) but it is a TLV **selection and reordering**, not a copy, and one unresolved trailer byte remains. Verbatim replay stays the default until matched captures settle it.
- `DEFAULT_RECIPE_PARAMS` is literally the hot-water recipe and `build_beverage_command` applies it to *every* beverage on the Soul path. The catalogue now has the real per-drink parameters, but nothing uses them yet - on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7vRLS5rHkazwsYZRTzVAE
