### PR TITLE
test: add the same machine dumped without the 50-character cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **A second test fixture: the same reference machine, dumped without the
+  50-character cut** (`tests/fixtures/soul_recipes_full.json`). The truncation
+  was never the machine's doing - it came from the dump script, and it was
+  hiding exactly the data worth having: 20 of the 28 factory descriptors carry
+  their min/default/max ranges past that cut. Readable parameter schemas go from
+  **8 to 27**.
+
+  The parser met these bytes for the first time here, having been written
+  against the truncated dump, and read all 137 blobs with **137/137 checksums
+  valid, nothing truncated, nothing left over by the TLV grammar**.
+
+  What that unlocks: whether a drink has been customised stops being unknown.
+  Espresso reads 48 ml on three of five profiles against a factory default of
+  40, so `off_default` now says so instead of `None`. Doppio sits exactly on its
+  factory 120 ml, and the tests pin both directions.
+
+  The two fixtures are kept side by side on purpose and are complementary rather
+  than nested: the truncated one exercises a real failure shape the parser has
+  to survive, and it still holds the one descriptor this one lacks - the
+  bean-system `0xc8`, which the old `_rec_` name filter never selected. That
+  filter is what selecting by blob family replaced.
+
+  It needs no anonymisation, and a test enforces that rather than trusting it:
+  recipe blobs only, no serial, no MAC, no user-entered text.
+
 ## [0.3.20] - 2026-09-04
 
 The machine has been publishing its own beverage catalogue all along, in the

--- a/tests/fixtures/soul_recipes_full.json
+++ b/tests/fixtures/soul_recipes_full.json
@@ -1,0 +1,413 @@
+{
+ "d001_rec_espresso": {
+  "value": "0CWw8AEIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBuZY="
+ },
+ "d002_rec_regular": {
+  "value": "0CGw8AIYAAEBGQABARsAAQQBAGQAtADwAgADBQQAAAAAzA=="
+ },
+ "d003_rec_long_coffee": {
+  "value": "0CGw8AMYAAEBGQABAQEAcwCgAPobAAEEAgADBQQAAAB65A=="
+ },
+ "d004_rec_2x_espresso": {
+  "value": "0CWw8AQIAQEBGAAAAAEAKABQAWgbAAEEAgAEBQQAAAAZAAEBlhU="
+ },
+ "d005_rec_doppio": {
+  "value": "0B2w8AUYAAEBGQABAQEAUAB4ALQbAAEEBAAAADiZ"
+ },
+ "d006_rec_americano": {
+  "value": "0Ciw8AYYAAEBGQABAQEAFAAoALQPADIAbgEsGwABBAIAAwUEAAAAtpc="
+ },
+ "d007_rec_cappuccino": {
+  "value": "0Cyw8AccAgICGAABARkAAQEBABQAQQC0GwABBAIAAwUJADIAqgQ4BAAAAKQ2"
+ },
+ "d008_rec_latte_macchiato": {
+  "value": "0Cyw8AgcAgICGAABARkAAQEBABQAPAC0GwABBAIAAwUJADIBIgQ4BAAAAJkd"
+ },
+ "d009_rec_caffelatte": {
+  "value": "0Cyw8AkcAgICGAABARkAAQEBABQAPAC0GwABBAIAAwUJADIBfAQGBAAAAKTu"
+ },
+ "d010_rec_flat_white": {
+  "value": "0DCw8AoMAQEBHAICAhgAAQEZAAEBAQAUADwAtBsAAQQCAAMFCQAyANwEOAQAAABjDg=="
+ },
+ "d011_rec_espr_macchiato": {
+  "value": "0Cyw8AscAgICGAABARkAAQEBABQAHgC0GwABBAIAAwUJAB4AKAQ4BAAAAOWP"
+ },
+ "d012_rec_hot_milk": {
+  "value": "0B2w8AwcAgICGAABARkAAQEJADIBaAQ4GwABBAf0"
+ },
+ "d013_rec_capp_doppio": {
+  "value": "0Ciw8A0cAgICGAABARkAAQEBAFAAZAC0GwABBAkAMgCWBDgEAAAAmt4="
+ },
+ "d014_rec_capp_reverse": {
+  "value": "0DCw8A8MAQEBHAICAhgAAQEZAAEBAQAUAEEAtBsAAQQCAAMFCQAyAKoEOAQAAAAAQg=="
+ },
+ "d015_rec_hot_water": {
+  "value": "0Bmw8BAYAAEBGQABAQ8AFAD6AaQbAAEEN5Y="
+ },
+ "d016_rec_tea": {
+  "value": "0B2w8BYYAAEBGQACAg8AFACWAaQbAAEEDQABA64W"
+ },
+ "d017_rec_coffee_pot": {
+  "value": "0CGw8BcZAAICAQB9AJYA+hsAAQMEAAAAHgAABQIFBQV1uA=="
+ },
+ "d018_rec_cortado": {
+  "value": "0DCw8BgMAQEBHAICAhgAAQEZAAEBAQAUACgAtBsAAQQCAAMFCQAeACgEOAQAAACYyQ=="
+ },
+ "d019_rec_long_black": {
+  "value": "0CWw8BkIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBlyE="
+ },
+ "d020_rec_mug_to_go": {
+  "value": "0CWw8BoIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBfOs="
+ },
+ "d021_rec_brew_over_ice": {
+  "value": "0CWw8BsIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBJa0="
+ },
+ "d028_rec_custom_1": {
+  "value": "0Cyw8OYYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAATmS"
+ },
+ "d029_rec_custom_2": {
+  "value": "0Cyw8OcYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAAR84"
+ },
+ "d030_rec_custom_3": {
+  "value": "0Cyw8OgYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAAcsf"
+ },
+ "d031_rec_custom_4": {
+  "value": "0Cyw8OkYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAAe21"
+ },
+ "d032_rec_custom_5": {
+  "value": "0Cyw8OoYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAAYZL"
+ },
+ "d033_rec_custom_6": {
+  "value": "0Cyw8OsYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAAaDh"
+ },
+ "d039_1_rec_espresso": {
+  "value": "0BSm8AEBCAABADAbAgIEBAAZAQFp"
+ },
+ "d040_1_rec_regular": {
+  "value": "0BKm8AECGQEbAQEAtAIDBAAKng=="
+ },
+ "d041_1_rec_long_coffee": {
+  "value": "0BKm8AEDGQEBAKAbAQIDBABbfw=="
+ },
+ "d042_1_rec_2x_espresso": {
+  "value": "0BSm8AEECAEBAGAbAgIEBAAZAYj/"
+ },
+ "d043_1_rec_doppio": {
+  "value": "0BCm8AEFGQEBAHgbAQQAnXY="
+ },
+ "d044_1_rec_americano": {
+  "value": "0BWm8AEGGQEBACgPAG4bAQIDBAAyqA=="
+ },
+ "d045_1_rec_cappuccino": {
+  "value": "0Bem8AEHHAIZAQEAThsCAgMJAMwEAN8z"
+ },
+ "d046_1_rec_latte_macchiato": {
+  "value": "0Bem8AEIHAIZAQEASBsCAgMJAVwEAFe/"
+ },
+ "d047_1_rec_caffelatte": {
+  "value": "0Bem8AEJHAIZAQEAPBsBAgMJAXwEAHta"
+ },
+ "d048_1_rec_flat_white": {
+  "value": "0Bmm8AEKDAEcAhkBAQA8GwECAwkA3AQAeyM="
+ },
+ "d049_1_rec_espr_macchiato": {
+  "value": "0Bem8AELHAIZAQEAHhsBAgMJACgEAEmj"
+ },
+ "d050_1_rec_hot_milk": {
+  "value": "0BCm8AEMHAIZAQkBaBsBJPo="
+ },
+ "d051_1_rec_capp_doppio": {
+  "value": "0BWm8AENHAIZAQEAZBsBCQCWBABQVg=="
+ },
+ "d052_1_rec_capp_reverse": {
+  "value": "0Bmm8AEPDAEcAhkBAQBBGwECAwkAqgQA0DE="
+ },
+ "d053_1_rec_hot_water": {
+  "value": "0A6m8AEQGQEPAPobAU9C"
+ },
+ "d054_1_rec_tea": {
+  "value": "0BCm8AEWGQIPAJYbAQ0BHM8="
+ },
+ "d055_1_rec_coffee_pot": {
+  "value": "0BKm8AEXGQIBAJYbAQQAAgWsVg=="
+ },
+ "d056_1_rec_cortado": {
+  "value": "0Bmm8AEYDAEcAhkBAQAoGwECAwkAKAQA4VA="
+ },
+ "d057_1_rec_long_black": {
+  "value": "0BSm8AEZCAABADAbAgIEBAAZASz1"
+ },
+ "d058_1_rec_mug_to_go": {
+  "value": "0BSm8AEaCAABADAbAgIEBAAZAaFW"
+ },
+ "d059_1_rec_brew_over_ice": {
+  "value": "0BSm8AEbCAABADAbAgIEBAAZAdo3"
+ },
+ "d060_2_rec_espresso": {
+  "value": "0BSm8AIBCAABACgbAQIEBAAZAUDP"
+ },
+ "d061_2_rec_regular": {
+  "value": "0BKm8AICGQEbAQEAtAIDBADFOw=="
+ },
+ "d062_2_rec_long_coffee": {
+  "value": "0BKm8AIDGQEBAKAbAQIDBACU2g=="
+ },
+ "d063_2_rec_2x_espresso": {
+  "value": "0BSm8AIECAEBAFAbAQIEBAAZAUda"
+ },
+ "d064_2_rec_doppio": {
+  "value": "0BCm8AIFGQEBAHgbAQQA5Yw="
+ },
+ "d065_2_rec_americano": {
+  "value": "0BWm8AIGGQEBACgPAG4bAQIDBADa5Q=="
+ },
+ "d066_2_rec_cappuccino": {
+  "value": "0Bem8AIHHAIZAQEAThsCAgMJAMwEAN9B"
+ },
+ "d067_2_rec_latte_macchiato": {
+  "value": "0Bem8AIIHAIZAQEAPBsBAgMJASIEAC4F"
+ },
+ "d068_2_rec_caffelatte": {
+  "value": "0Bem8AIJHAIZAQEAPBsBAgMJAXwEAHso"
+ },
+ "d069_2_rec_flat_white": {
+  "value": "0Bmm8AIKDAEcAhkBAQA8GwECAwkA3AQAJfY="
+ },
+ "d070_2_rec_espr_macchiato": {
+  "value": "0Bem8AILHAIZAQEAHhsBAgMJACgEAEnR"
+ },
+ "d071_2_rec_hot_milk": {
+  "value": "0BCm8AIMHAIZAQkBaBsBXAA="
+ },
+ "d072_2_rec_capp_doppio": {
+  "value": "0BWm8AINHAIZAQEAZBsBCQCWBAC4Gw=="
+ },
+ "d073_2_rec_capp_reverse": {
+  "value": "0Bmm8AIPDAEcAhkBAQBBGwECAwkAqgQAjuQ="
+ },
+ "d074_2_rec_hot_water": {
+  "value": "0A6m8AIQGQEPAPobAWIG"
+ },
+ "d075_2_rec_tea": {
+  "value": "0BCm8AIWGQIPAOEbAw0CQGQ="
+ },
+ "d076_2_rec_coffee_pot": {
+  "value": "0BKm8AIXGQIBAJYbAQQAAgVj8w=="
+ },
+ "d077_2_rec_cortado": {
+  "value": "0Bmm8AIYDAEcAhkBAQAoGwECAwkAKAQAv4U="
+ },
+ "d078_2_rec_long_black": {
+  "value": "0BSm8AIZCAABACgbAQIEBAAZAW1T"
+ },
+ "d079_2_rec_mug_to_go": {
+  "value": "0BSm8AIaCAABACgbAQIEBAAZAeDw"
+ },
+ "d080_2_rec_brew_over_ice": {
+  "value": "0BSm8AIbCAABACgbAQIEBAAZAZuR"
+ },
+ "d081_3_rec_espresso": {
+  "value": "0BSm8AMBCAABACgbAQIEBAAZAe4z"
+ },
+ "d082_3_rec_regular": {
+  "value": "0BKm8AMCGQEbAQEAtAIDBACAWA=="
+ },
+ "d083_3_rec_long_coffee": {
+  "value": "0BKm8AMDGQEBAKAbAQIDBADRuQ=="
+ },
+ "d084_3_rec_2x_espresso": {
+  "value": "0BSm8AMECAEBAFAbAQIEBAAZAemm"
+ },
+ "d085_3_rec_doppio": {
+  "value": "0BCm8AMFGQEBAHgbAQQAPcU="
+ },
+ "d086_3_rec_americano": {
+  "value": "0BWm8AMGGQEBACgPAG4bAQIDBABywQ=="
+ },
+ "d087_3_rec_cappuccino": {
+  "value": "0Bem8AMHHAIZAQEAQRsBAgMJAKoEAJh/"
+ },
+ "d088_3_rec_latte_macchiato": {
+  "value": "0Bem8AMIHAIZAQEAPBsBAgMJASIEAN40"
+ },
+ "d089_3_rec_caffelatte": {
+  "value": "0Bem8AMJHAIZAQEAPBsBAgMJAXwEAIsZ"
+ },
+ "d090_3_rec_flat_white": {
+  "value": "0Bmm8AMKDAEcAhkBAQA8GwECAwkA3AQAEEU="
+ },
+ "d091_3_rec_espr_macchiato": {
+  "value": "0Bem8AMLHAIZAQEAHhsBAgMJACgEALng"
+ },
+ "d092_3_rec_hot_milk": {
+  "value": "0BCm8AMMHAIZAQkBaBsBhEk="
+ },
+ "d093_3_rec_capp_doppio": {
+  "value": "0BWm8AMNHAIZAQEAZBsBCQCWBAAQPw=="
+ },
+ "d094_3_rec_capp_reverse": {
+  "value": "0Bmm8AMPDAEcAhkBAQBBGwECAwkAqgQAu1c="
+ },
+ "d095_3_rec_hot_water": {
+  "value": "0A6m8AMQGQEPAPobAYkl"
+ },
+ "d096_3_rec_tea": {
+  "value": "0BCm8AMWGQIPAJYbAQ0BvHw="
+ },
+ "d097_3_rec_coffee_pot": {
+  "value": "0BKm8AMXGQIBAJYbAQQAAgUmkA=="
+ },
+ "d098_3_rec_cortado": {
+  "value": "0Bmm8AMYDAEcAhkBAQAoGwECAwkAKAQAijY="
+ },
+ "d099_3_rec_long_black": {
+  "value": "0BSm8AMZCAABACgbAQIEBAAZAcOv"
+ },
+ "d100_3_rec_mug_to_go": {
+  "value": "0BSm8AMaCAABACgbAQIEBAAZAU4M"
+ },
+ "d101_3_rec_brew_over_ice": {
+  "value": "0BSm8AMbCAABACgbAQIEBAAZATVt"
+ },
+ "d102_4_rec_espresso": {
+  "value": "0BSm8AQBCAABADAbAgIEBAAZATQn"
+ },
+ "d103_4_rec_regular": {
+  "value": "0BKm8AQCGQEbAQEAtAIDBABKUA=="
+ },
+ "d104_4_rec_long_coffee": {
+  "value": "0BKm8AQDGQEBAKAbAQIDBAAbsQ=="
+ },
+ "d105_4_rec_2x_espresso": {
+  "value": "0BSm8AQECAEBAGAbAgIEBAAZAb2x"
+ },
+ "d106_4_rec_doppio": {
+  "value": "0BCm8AQFGQEBAHgbAQQAFHg="
+ },
+ "d107_4_rec_americano": {
+  "value": "0BWm8AQGGQEBACgPAG4bAQIDBAAaXg=="
+ },
+ "d108_4_rec_cappuccino": {
+  "value": "0Bem8AQHHAIZAQEAThsCAgMJAMwEAN+l"
+ },
+ "d109_4_rec_latte_macchiato": {
+  "value": "0Bem8AQIHAIZAQEASBsCAgMJAVwEAFcp"
+ },
+ "d110_4_rec_caffelatte": {
+  "value": "0Bem8AQJHAIZAQEAPBsBAgMJAXwEAHvM"
+ },
+ "d111_4_rec_flat_white": {
+  "value": "0Bmm8AQKDAEcAhkBAQA8GwECAwkA3AQAmFw="
+ },
+ "d112_4_rec_espr_macchiato": {
+  "value": "0Bem8AQLHAIZAQEAHhsBAgMJACgEAEk1"
+ },
+ "d113_4_rec_hot_milk": {
+  "value": "0BCm8AQMHAIZAQkBaBsBrfQ="
+ },
+ "d114_4_rec_capp_doppio": {
+  "value": "0BWm8AQNHAIZAQEAZBsBCQCWBAB4oA=="
+ },
+ "d115_4_rec_capp_reverse": {
+  "value": "0Bmm8AQPDAEcAhkBAQBBGwECAwkAqgQAM04="
+ },
+ "d116_4_rec_hot_water": {
+  "value": "0A6m8AQQGQEPAPobATiO"
+ },
+ "d117_4_rec_tea": {
+  "value": "0BCm8AQWGQIPAJYbAQ0BlcE="
+ },
+ "d118_4_rec_coffee_pot": {
+  "value": "0BKm8AQXGQIBAJYbAQQAAgXsmA=="
+ },
+ "d119_4_rec_cortado": {
+  "value": "0Bmm8AQYDAEcAhkBAQAoGwECAwkAKAQAAi8="
+ },
+ "d120_4_rec_long_black": {
+  "value": "0BSm8AQZCAABADAbAgIEBAAZARm7"
+ },
+ "d121_4_rec_mug_to_go": {
+  "value": "0BSm8AQaCAABADAbAgIEBAAZAZQY"
+ },
+ "d122_4_rec_brew_over_ice": {
+  "value": "0BSm8AQbCAABADAbAgIEBAAZAe95"
+ },
+ "d123_5_rec_espresso": {
+  "value": "0BSm8AUBCAABADAbAgIEBAAZAZrb"
+ },
+ "d124_5_rec_regular": {
+  "value": "0BKm8AUCGQEbAQEAtAIDBAAPMw=="
+ },
+ "d125_5_rec_long_coffee": {
+  "value": "0BKm8AUDGQEBAKAbAQIDBABe0g=="
+ },
+ "d126_5_rec_2x_espresso": {
+  "value": "0BSm8AUECAEBAGAbAgIEBAAZARNN"
+ },
+ "d127_5_rec_doppio": {
+  "value": "0BCm8AUFGQEBAHgbAQQAzDE="
+ },
+ "d128_5_rec_americano": {
+  "value": "0BWm8AUGGQEBACgPAG4bAQIDBACyeg=="
+ },
+ "d129_5_rec_cappuccino": {
+  "value": "0Bem8AUHHAIZAQEAThsCAgMJAMwEAC+U"
+ },
+ "d130_5_rec_latte_macchiato": {
+  "value": "0Bem8AUIHAIZAQEASBsCAgMJAVwEAKcY"
+ },
+ "d131_5_rec_caffelatte": {
+  "value": "0Bem8AUJHAIZAQEAPBsBAgMJAXwEAIv9"
+ },
+ "d132_5_rec_flat_white": {
+  "value": "0Bmm8AUKDAEcAhkBAQA8GwECAwkA3AQAre8="
+ },
+ "d133_5_rec_espr_macchiato": {
+  "value": "0Bem8AULHAIZAQEAHhsBAgMJACgEALkE"
+ },
+ "d134_5_rec_hot_milk": {
+  "value": "0BCm8AUMHAIZAQkBaBsBdb0="
+ },
+ "d135_5_rec_capp_doppio": {
+  "value": "0BWm8AUNHAIZAQEAZBsBCQCWBADQhA=="
+ },
+ "d136_5_rec_capp_reverse": {
+  "value": "0Bmm8AUPDAEcAhkBAQBBGwECAwkAqgQABv0="
+ },
+ "d137_5_rec_hot_water": {
+  "value": "0A6m8AUQGQEPAPobAdOt"
+ },
+ "d138_5_rec_tea": {
+  "value": "0BCm8AUWGQIPAJYbAQ0BTYg="
+ },
+ "d139_5_rec_coffee_pot": {
+  "value": "0BKm8AUXGQIBAJYbAQQAAgWp+w=="
+ },
+ "d140_5_rec_cortado": {
+  "value": "0Bmm8AUYDAEcAhkBAQAoGwECAwkAKAQAN5w="
+ },
+ "d141_5_rec_long_black": {
+  "value": "0BSm8AUZCAABADAbAgIEBAAZAbdH"
+ },
+ "d142_5_rec_mug_to_go": {
+  "value": "0BSm8AUaCAABADAbAgIEBAAZATrk"
+ },
+ "d143_5_rec_brew_over_ice": {
+  "value": "0BSm8AUbCAABADAbAgIEBAAZAUGF"
+ },
+ "d261_1_rec_priority": {
+  "value": "0Bmo8AEFyAgHBgMMEAQWAQsXAgkKDQ8Ywjs="
+ },
+ "d262_2_rec_priority": {
+  "value": "0Bmo8ALICAcQFgwLAQMECQINFwoGBQ8Yxqo="
+ },
+ "d263_3_rec_priority": {
+  "value": "0Bmo8APIAQQDBwkXCAoGBQsMAg0PGBAWoKg="
+ },
+ "d264_4_rec_priority": {
+  "value": "0Bmo8AQFyAgHBgMMEAQWAQsXAgkKDQ8YIUQ="
+ },
+ "d265_5_rec_priority": {
+  "value": "0Bmo8AUFyAgHBgMMEAQWAQsXAgkKDQ8YFPc="
+ }
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -663,3 +663,113 @@ def test_blob_family_reads_the_family_without_a_full_decode(props: dict):
     assert catalog.blob_family(props["d270_serialnumber"]["value"]) == b"\xa1\x0f"
     for not_a_blob in (None, "", "AA==", "not base64 !!", 42, "QUJDRA=="):
         assert catalog.blob_family(not_a_blob) is None
+
+
+# --- the same machine, dumped without the 50-character cut ------------------ #
+#
+# fixtures/soul_properties.json is a full 312-property dump whose values the
+# dump tool truncated at 50 base64 characters, which is a real shape the parser
+# has to survive - 31 of its blobs are cut, including 20 of the 28 factory
+# descriptors. This second fixture is the same machine's recipe datapoints read
+# again with that cut removed: fewer properties, but every one of them whole.
+#
+# It needs no anonymisation and that is not an oversight: it carries recipe
+# blobs only, no serial, no MAC, no user-entered text. The test below enforces
+# it rather than trusting it.
+
+FULL_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "soul_recipes_full.json"
+
+
+@pytest.fixture(scope="module")
+def full_props() -> dict:
+    return json.loads(FULL_FIXTURE.read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def full_cat(full_props: dict) -> dict:
+    return catalog.build_catalog(full_props)
+
+
+def test_the_full_dump_parses_with_nothing_left_over(full_cat: dict):
+    """137 blobs, 137 checksums, nothing cut and nothing the grammar could not eat.
+
+    This is the parser's first run against bytes it was not written from: the
+    truncated dump is what it was developed on, this one arrived afterwards.
+    """
+    stats = full_cat["stats"]
+    assert stats["blobs"] == 137
+    assert stats["crc_ok"] == 137
+    assert stats["crc_failed"] == 0
+    assert stats["truncated"] == 0
+    assert stats["unparsed_payloads"] == 0
+    assert stats["short_payloads"] == 0
+
+
+def test_removing_the_cut_turns_8_readable_schemas_into_27(cat: dict, full_cat: dict):
+    """The truncation was hiding the machine's own parameter ranges.
+
+    Same machine, same descriptors: 20 of the 28 were unreadable purely because
+    the dump tool stopped at 50 base64 characters.
+
+    The two fixtures are complementary rather than nested, and the one id that
+    proves it is worth keeping: the bean-system descriptor `0xc8` is readable in
+    the truncated dump and absent from this one, because the dump that produced
+    it still selected properties by the `_rec_` substring, which never matched
+    `d022_beansystem_1`. That filter is what selecting by blob family replaced.
+    """
+    truncated_ranges = {i for i, item in cat["beverages"].items() if item["ranges"]}
+    full_ranges = {i for i, item in full_cat["beverages"].items() if item["ranges"]}
+    assert len(truncated_ranges) == 8
+    assert len(full_ranges) == 27
+    assert truncated_ranges - full_ranges == {0xC8}, "only the bean system, and only by name filter"
+    assert truncated_ranges - {0xC8} < full_ranges, "every truncated-dump range survives"
+
+
+def test_espresso_ranges_are_now_readable(full_cat: dict):
+    """Espresso is the drink whose descriptor the old dump cut in half."""
+    espresso = full_cat["beverages"][0x01]
+    assert espresso["descriptor_truncated"] is False
+    assert espresso["ranges"][catalog.TAG_COFFEE_ML] == (20, 40, 180)
+    assert espresso["ranges"][catalog.TAG_TEMPERATURE] == (0, 1, 4)
+
+
+def test_customisation_becomes_knowable_instead_of_unknown(cat: dict, full_cat: dict):
+    """`off_default` was None for espresso only because the default was missing.
+
+    With the factory descriptor readable, the same per-profile values resolve to
+    a definite answer: 48 ml against a factory 40 is a customisation, and the
+    parser now says so rather than shrugging.
+    """
+    assert cat["beverages"][0x01]["off_default"] is None
+    espresso = full_cat["beverages"][0x01]
+    assert espresso["off_default"][catalog.TAG_COFFEE_ML] is True
+    volumes = {p[catalog.TAG_COFFEE_ML] for p in espresso["profiles"].values()}
+    assert volumes == {40, 48}
+
+    # And the mirror case, so this does not just assert that everything is
+    # customised: doppio sits exactly on its factory default on every profile.
+    doppio = full_cat["beverages"][0x05]
+    assert doppio["ranges"][catalog.TAG_COFFEE_ML][1] == 120
+    assert doppio["off_default"][catalog.TAG_COFFEE_ML] is False
+
+
+def test_the_recipe_fixture_needs_no_anonymisation(full_props: dict):
+    """Recipe blobs only - no serial, no MAC, no name the household typed in.
+
+    Pinned rather than assumed, because the day someone refreshes this file from
+    a wider dump is the day it starts carrying identifiers.
+    """
+    import re
+
+    for name, prop in full_props.items():
+        raw = catalog._b64_bytes(prop["value"])
+        assert raw is not None, name
+        for encoding in ("utf-16-be", "latin-1"):
+            text = raw.decode(encoding, "ignore")
+            assert not re.search(r"[A-Za-z][A-Za-z0-9 ._/()-]{3,}", text), f"{name}: {text!r}"
+    families = {catalog.blob_family(p["value"]) for p in full_props.values()}
+    assert families <= {
+        catalog.FAMILY_DESCRIPTOR,
+        catalog.FAMILY_PROFILE_RECIPE,
+        catalog.FAMILY_MENU,
+    }, "a text-bearing family would need the anonymiser"


### PR DESCRIPTION
The truncation in `fixtures/soul_properties.json` was never the machine's doing. It came from the dump script, and it hid exactly the data worth having: 20 of the 28 factory descriptors carry their min/default/max ranges past that cut. Readable parameter schemas go from **8 to 27**.

**The parser met these bytes for the first time here.** It was written against the truncated dump; this fixture arrived afterwards, from a fresh read with the cut removed. It read all 137 blobs with **137/137 checksums valid, nothing truncated, and nothing left over by the TLV grammar**.

**What it unlocks** is the signal that was stuck on `unknown`: whether a drink has actually been customised. Espresso reads 48 ml on three of five profiles against a factory default of 40, so `off_default` now resolves to `True` instead of `None`. Doppio sits exactly on its factory 120 ml. Both directions are pinned, so a future edit cannot quietly make everything look customised.

**Both fixtures are kept, and they are complementary rather than nested.** The truncated one exercises a failure shape the parser has to survive on real hardware, and it still holds the one descriptor this one lacks: the bean-system `0xc8`, which the old `_rec_` name filter never selected. Selecting by blob family is what replaced that filter, so a dump taken on v0.3.20 would carry it.

**No anonymisation needed**, and a test enforces that rather than trusting it: recipe blobs only, no serial, no MAC, no user-entered text. The day someone refreshes this file from a wider dump, that test fails.

253 tests pass, ruff clean. Two deliberate mutations of the parser were each caught by the new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7vRLS5rHkazwsYZRTzVAE