### PR TITLE
test: read the reference machine whole, and drop a guard that decided nothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,20 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **`_slot_is_defined` no longer checks the `0xff` intensity marker.** A slot
+  that dispenses nothing has not been programmed, and that was already the whole
+  test: every unprogrammed slot on the reference machine reads zero for coffee,
+  milk and water, so the marker decided nothing. Removing it also removes a
+  claim about what `0xff` means that no machine has had to confirm - and were a
+  slot ever to carry a real volume alongside it, "it pours something, so it is
+  programmed" is the answer we would want anyway. Found by mutating the guard
+  and watching the suite stay green.
+
 ### Added
-- **A second test fixture: the same reference machine, dumped without the
-  50-character cut** (`tests/fixtures/soul_recipes_full.json`). The truncation
+- **A second test fixture: the same reference machine, read whole**
+  (`tests/fixtures/soul_recipes_full.json`), straight off the running
+  integration on v0.3.20. The truncation
   was never the machine's doing - it came from the dump script, and it was
   hiding exactly the data worth having: 20 of the 28 factory descriptors carry
   their min/default/max ranges past that cut. Readable parameter schemas go from
@@ -16,19 +27,23 @@ All notable changes to this project will be documented in this file.
   against the truncated dump, and read all 137 blobs with **137/137 checksums
   valid, nothing truncated, nothing left over by the TLV grammar**.
 
-  What that unlocks: whether a drink has been customised stops being unknown.
-  Espresso reads 48 ml on three of five profiles against a factory default of
-  40, so `off_default` now says so instead of `None`. Doppio sits exactly on its
-  factory 120 ml, and the tests pin both directions.
+  What that unlocks: **nothing about this machine is unknown any more**. Whether
+  a drink has been customised stops being a shrug - espresso reads 48 ml on
+  three of five profiles against a factory default of 40, so `off_default` now
+  says so instead of `None`, while doppio sits exactly on its factory 120 ml.
+  Both directions are pinned. Because the dump now selects by blob family, the
+  fixture also reaches what the old `_rec_` name filter never did: the six
+  saved-recipe slots (read as unprogrammed from the machine's own values, not
+  guessed) and the bean-system drink `0xc8`, which no hardcoded beverage list
+  has ever carried and which turns out to declare coffee 30/40/60 ml.
 
-  The two fixtures are kept side by side on purpose and are complementary rather
-  than nested: the truncated one exercises a real failure shape the parser has
-  to survive, and it still holds the one descriptor this one lacks - the
-  bean-system `0xc8`, which the old `_rec_` name filter never selected. That
-  filter is what selecting by blob family replaced.
+  The truncated fixture is kept alongside it, and not out of sentiment: 31 of
+  its blobs are cut, which is a real shape the parser has to survive.
 
-  It needs no anonymisation, and a test enforces that rather than trusting it:
-  recipe blobs only, no serial, no MAC, no user-entered text.
+  Neither needs anonymisation, and tests enforce that rather than trusting it.
+  The dump renders recipe families only - no serial, no settings PIN, no monitor
+  blob - and redacts the user-entered text of the three name families, which is
+  why those blobs are absent rather than scrubbed.
 
 ## [0.3.20] - 2026-09-04
 

--- a/custom_components/delonghi_coffeelink/catalog.py
+++ b/custom_components/delonghi_coffeelink/catalog.py
@@ -104,9 +104,6 @@ WIDE_TAGS = frozenset({0x01, 0x09, 0x0F})
 CUSTOM_SLOT_IDS = frozenset(range(0xE6, 0xEC))
 BEAN_SYSTEM_IDS = frozenset(range(0xC8, 0xCE))
 
-#: An unprogrammed custom slot: no coffee quantity and the 0xff intensity marker.
-_EMPTY_SLOT_INTENSITY = 0xFF
-
 # Tag meanings pinned by value range against the reference machine. Only the
 # five below are confirmed; the rest are carried through unnamed rather than
 # guessed at.
@@ -338,12 +335,15 @@ def _new_entry(bev_id: int) -> dict:
 def _slot_is_defined(params: dict[int, int]) -> bool:
     """True when a custom slot has actually been programmed on the machine.
 
-    An untouched slot reads back as coffee quantity 0 with the 0xff intensity
-    marker - the machine's own "not defined yet" state.
+    A slot that dispenses nothing has not been programmed. That is the whole
+    test, and it is deliberately the only one: an untouched slot on the
+    reference machine also carries ``0x02 = 0xff`` where a programmed drink
+    carries an intensity, but every such slot already reads zero for coffee,
+    milk and water, so checking the marker as well decided nothing. Dropping it
+    also drops a claim about what ``0xff`` means, which no machine has yet had
+    to confirm - and were a slot ever to carry a real volume alongside it, "it
+    pours something, so it is programmed" is the answer we would want anyway.
     """
-    unset = params.get(TAG_INTENSITY) == _EMPTY_SLOT_INTENSITY
-    if unset and not params.get(TAG_COFFEE_ML):
-        return False
     return any(params.get(tag) for tag in (TAG_COFFEE_ML, TAG_MILK, TAG_WATER_ML))
 
 

--- a/tests/fixtures/soul_recipes_full.json
+++ b/tests/fixtures/soul_recipes_full.json
@@ -62,6 +62,9 @@
  "d021_rec_brew_over_ice": {
   "value": "0CWw8BsIAAABGAABAQEAFAAoALQbAAEEAgAEBQQAAAAZAAEBJa0="
  },
+ "d022_beansystem_1": {
+  "value": "0B2w8MgYAAEBAQAeACgAPBsAAQQCAQQFGQACAoMB"
+ },
  "d028_rec_custom_1": {
   "value": "0Cyw8OYYAAEBAQAUAAAAtAIA/wUJADIAAAQ4BAAAAAwAAAEcAAAEGQAAATmS"
  },
@@ -394,6 +397,111 @@
  },
  "d143_5_rec_brew_over_ice": {
   "value": "0BSm8AUbCAABADAbAgIEBAAZAUGF"
+ },
+ "d160_1_bs_recipe_01": {
+  "value": "0BCm8AHIAQAoGwECAhkBQ9k="
+ },
+ "d166_2_bs_recipe_01": {
+  "value": "0BCm8ALIAQAgGwACAhkBAt8="
+ },
+ "d172_3_bs_recipe_01": {
+  "value": "0BCm8APIAQAoGwECAhkB42o="
+ },
+ "d178_4_bs_recipe_01": {
+  "value": "0BCm8ATIAQAoGwECAhkBytc="
+ },
+ "d184_5_bs_recipe_01": {
+  "value": "0BCm8AXIAQAoGwECAhkBEp4="
+ },
+ "d200_1_cstm_recipe_01": {
+  "value": "0Bem8AHmAQAAAv8JAAAEAAwAHAAZABK3"
+ },
+ "d201_1_cstm_recipe_02": {
+  "value": "0Bem8AHnAQAAAv8JAAAEAAwAHAAZAAJV"
+ },
+ "d202_1_cstm_recipe_03": {
+  "value": "0Bem8AHoAQAAAv8JAAAEAAwAHAAZAPfr"
+ },
+ "d203_1_cstm_recipe_04": {
+  "value": "0Bem8AHpAQAAAv8JAAAEAAwAHAAZAOcJ"
+ },
+ "d204_1_cstm_recipe_05": {
+  "value": "0Bem8AHqAQAAAv8JAAAEAAwAHAAZANYv"
+ },
+ "d205_1_cstm_recipe_06": {
+  "value": "0Bem8AHrAQAAAv8JAAAEAAwAHAAZAMbN"
+ },
+ "d206_2_cstm_recipe_01": {
+  "value": "0Bem8ALmAQAAAv8JAAAEAAwAHAAZABLF"
+ },
+ "d207_2_cstm_recipe_02": {
+  "value": "0Bem8ALnAQAAAv8JAAAEAAwAHAAZAAIn"
+ },
+ "d208_2_cstm_recipe_03": {
+  "value": "0Bem8ALoAQAAAv8JAAAEAAwAHAAZAPeZ"
+ },
+ "d209_2_cstm_recipe_04": {
+  "value": "0Bem8ALpAQAAAv8JAAAEAAwAHAAZAOd7"
+ },
+ "d210_2_cstm_recipe_05": {
+  "value": "0Bem8ALqAQAAAv8JAAAEAAwAHAAZANZd"
+ },
+ "d211_2_cstm_recipe_06": {
+  "value": "0Bem8ALrAQAAAv8JAAAEAAwAHAAZAMa/"
+ },
+ "d212_3_cstm_recipe_01": {
+  "value": "0Bem8APmAQAAAv8JAAAEAAwAHAAZAOL0"
+ },
+ "d213_3_cstm_recipe_02": {
+  "value": "0Bem8APnAQAAAv8JAAAEAAwAHAAZAPIW"
+ },
+ "d214_3_cstm_recipe_03": {
+  "value": "0Bem8APoAQAAAv8JAAAEAAwAHAAZAAeo"
+ },
+ "d215_3_cstm_recipe_04": {
+  "value": "0Bem8APpAQAAAv8JAAAEAAwAHAAZABdK"
+ },
+ "d216_3_cstm_recipe_05": {
+  "value": "0Bem8APqAQAAAv8JAAAEAAwAHAAZACZs"
+ },
+ "d217_3_cstm_recipe_06": {
+  "value": "0Bem8APrAQAAAv8JAAAEAAwAHAAZADaO"
+ },
+ "d218_4_cstm_recipe_01": {
+  "value": "0Bem8ATmAQAAAv8JAAAEAAwAHAAZABIh"
+ },
+ "d219_4_cstm_recipe_02": {
+  "value": "0Bem8ATnAQAAAv8JAAAEAAwAHAAZAALD"
+ },
+ "d220_4_cstm_recipe_03": {
+  "value": "0Bem8AToAQAAAv8JAAAEAAwAHAAZAPd9"
+ },
+ "d221_4_cstm_recipe_04": {
+  "value": "0Bem8ATpAQAAAv8JAAAEAAwAHAAZAOef"
+ },
+ "d222_4_cstm_recipe_05": {
+  "value": "0Bem8ATqAQAAAv8JAAAEAAwAHAAZANa5"
+ },
+ "d223_4_cstm_recipe_06": {
+  "value": "0Bem8ATrAQAAAv8JAAAEAAwAHAAZAMZb"
+ },
+ "d224_5_cstm_recipe_01": {
+  "value": "0Bem8AXmAQAAAv8JAAAEAAwAHAAZAOIQ"
+ },
+ "d225_5_cstm_recipe_02": {
+  "value": "0Bem8AXnAQAAAv8JAAAEAAwAHAAZAPLy"
+ },
+ "d226_5_cstm_recipe_03": {
+  "value": "0Bem8AXoAQAAAv8JAAAEAAwAHAAZAAdM"
+ },
+ "d227_5_cstm_recipe_04": {
+  "value": "0Bem8AXpAQAAAv8JAAAEAAwAHAAZABeu"
+ },
+ "d228_5_cstm_recipe_05": {
+  "value": "0Bem8AXqAQAAAv8JAAAEAAwAHAAZACaI"
+ },
+ "d229_5_cstm_recipe_06": {
+  "value": "0Bem8AXrAQAAAv8JAAAEAAwAHAAZADZq"
  },
  "d261_1_rec_priority": {
   "value": "0Bmo8AEFyAgHBgMMEAQWAQsXAgkKDQ8Ywjs="

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -665,17 +665,21 @@ def test_blob_family_reads_the_family_without_a_full_decode(props: dict):
         assert catalog.blob_family(not_a_blob) is None
 
 
-# --- the same machine, dumped without the 50-character cut ------------------ #
+# --- the same machine, read whole ------------------------------------------- #
 #
 # fixtures/soul_properties.json is a full 312-property dump whose values the
 # dump tool truncated at 50 base64 characters, which is a real shape the parser
 # has to survive - 31 of its blobs are cut, including 20 of the 28 factory
-# descriptors. This second fixture is the same machine's recipe datapoints read
-# again with that cut removed: fewer properties, but every one of them whole.
+# descriptors. This second fixture is the same machine's catalogue read again
+# with that cut removed, straight off the running integration: fewer properties,
+# but every one of them whole, and it reaches the saved-recipe and bean-system
+# blobs the old `_rec_` name filter never selected.
 #
-# It needs no anonymisation and that is not an oversight: it carries recipe
-# blobs only, no serial, no MAC, no user-entered text. The test below enforces
-# it rather than trusting it.
+# It needs no anonymisation and that is not an oversight. The dump it came from
+# renders recipe families only - no serial, no settings PIN, no monitor blob -
+# and redacts the user-entered text of the three name families, which is why
+# those 11 blobs are absent here rather than anonymised. The test below enforces
+# the result rather than trusting it.
 
 FULL_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "soul_recipes_full.json"
 
@@ -691,38 +695,36 @@ def full_cat(full_props: dict) -> dict:
 
 
 def test_the_full_dump_parses_with_nothing_left_over(full_cat: dict):
-    """137 blobs, 137 checksums, nothing cut and nothing the grammar could not eat.
+    """173 blobs, 173 checksums, nothing cut and nothing the grammar could not eat.
 
     This is the parser's first run against bytes it was not written from: the
     truncated dump is what it was developed on, this one arrived afterwards.
     """
     stats = full_cat["stats"]
-    assert stats["blobs"] == 137
-    assert stats["crc_ok"] == 137
+    assert stats["blobs"] == 173
+    assert stats["crc_ok"] == 173
     assert stats["crc_failed"] == 0
     assert stats["truncated"] == 0
     assert stats["unparsed_payloads"] == 0
     assert stats["short_payloads"] == 0
 
 
-def test_removing_the_cut_turns_8_readable_schemas_into_27(cat: dict, full_cat: dict):
+def test_removing_the_cut_makes_every_schema_readable(cat: dict, full_cat: dict):
     """The truncation was hiding the machine's own parameter ranges.
 
     Same machine, same descriptors: 20 of the 28 were unreadable purely because
     the dump tool stopped at 50 base64 characters.
 
-    The two fixtures are complementary rather than nested, and the one id that
-    proves it is worth keeping: the bean-system descriptor `0xc8` is readable in
-    the truncated dump and absent from this one, because the dump that produced
-    it still selected properties by the `_rec_` substring, which never matched
-    `d022_beansystem_1`. That filter is what selecting by blob family replaced.
+    Every id the truncated dump could read is still readable here, and the set
+    is now complete: 28 of 28, including the bean-system descriptor `0xc8` that
+    the old `_rec_` name filter never even selected.
     """
     truncated_ranges = {i for i, item in cat["beverages"].items() if item["ranges"]}
     full_ranges = {i for i, item in full_cat["beverages"].items() if item["ranges"]}
     assert len(truncated_ranges) == 8
-    assert len(full_ranges) == 27
-    assert truncated_ranges - full_ranges == {0xC8}, "only the bean system, and only by name filter"
-    assert truncated_ranges - {0xC8} < full_ranges, "every truncated-dump range survives"
+    assert full_ranges == set(full_cat["beverages"]), "every declared id has its schema"
+    assert len(full_ranges) == 28
+    assert truncated_ranges < full_ranges, "nothing readable before became unreadable"
 
 
 def test_espresso_ranges_are_now_readable(full_cat: dict):
@@ -773,3 +775,38 @@ def test_the_recipe_fixture_needs_no_anonymisation(full_props: dict):
         catalog.FAMILY_PROFILE_RECIPE,
         catalog.FAMILY_MENU,
     }, "a text-bearing family would need the anonymiser"
+
+
+def test_nothing_about_this_machine_is_unknown_any_more(full_cat: dict):
+    """The whole point of reading the machine whole: no shrugging left.
+
+    Every declared drink has its factory schema, so `off_default` resolves to a
+    real answer for all of them. On the truncated dump 20 of the 28 had to say
+    `None`.
+    """
+    assert all(item["off_default"] is not None for item in full_cat["beverages"].values())
+    assert all(item["descriptor_truncated"] is False for item in full_cat["beverages"].values())
+
+
+def test_the_saved_recipe_slots_are_read_and_reported_empty(full_cat: dict):
+    """Six slots, five profiles each, none programmed on the reference machine.
+
+    These blobs are the ones the old `_rec_` name filter never selected, so they
+    could not be tested against real bytes until the dump learned to select by
+    family. `defined` is False here, not None: the machine's own unprogrammed
+    sentinel was read, not guessed.
+    """
+    custom = {i: item for i, item in full_cat["beverages"].items() if item["kind"] == "custom"}
+    assert set(custom) == set(catalog.CUSTOM_SLOT_IDS)
+    assert all(item["defined"] is False for item in custom.values())
+    assert all(len(item["profiles"]) == 5 for item in custom.values())
+
+
+def test_the_bean_system_drink_carries_a_real_schema(full_cat: dict):
+    """`0xc8` is brewable, has ranges, and is in no hardcoded beverage list."""
+    bean = full_cat["beverages"][0xC8]
+    assert bean["kind"] == "bean_system"
+    assert bean["ranges"][catalog.TAG_COFFEE_ML] == (30, 40, 60)
+    assert bean["ranges"][catalog.TAG_INTENSITY] == (1, 4, 5)
+    assert len(bean["profiles"]) == 5, "one per-profile recipe per profile"
+    assert bean["on_menu"] is None, "the menu blob does not enumerate it"


### PR DESCRIPTION
The recipe fixture is now the same machine read again on v0.3.20, off the running integration. Same 137 properties byte for byte, plus **36 the old `_rec_` name filter never selected**: the 30 saved-recipe blobs, the 5 bean-system recipes and `d022_beansystem_1`. A third fixture would have been a strict subset of this one, so there is not one.

**173 blobs, 173/173 checksums valid, nothing truncated, nothing left over by the TLV grammar**, and **28 of 28** declared drinks now carry their factory min/default/max schema.

**Nothing about this machine is unknown any more.** `off_default` resolves for every drink, where the truncated dump left 20 of 28 saying `None`. Espresso reads 48 ml on three of five profiles against a factory 40, so it is reported as customised; doppio sits exactly on its factory 120 ml. Both directions pinned.

**Newly testable against real bytes**: the six saved-recipe slots, read as unprogrammed from the machine's own values rather than guessed, and the bean-system drink `0xc8` - brewable, in no hardcoded beverage list, declaring coffee 30/40/60 ml.

### Also: a guard that decided nothing

`_slot_is_defined` checked the `0xff` intensity marker before falling back to "does it dispense anything". Mutating that guard left the suite green, which was the tell: every unprogrammed slot already reads zero for coffee, milk and water, so the marker never changed an answer. Removing it also removes a claim about what `0xff` means that no machine has had to confirm - and were a slot ever to carry a real volume alongside it, "it pours something, so it is programmed" is the answer we would want anyway. Both directions of the simplified test are now pinned by mutation.

### What is kept, and why

The truncated fixture stays. 31 of its blobs are cut, and that is a real shape the parser has to survive on hardware.

Neither fixture needs anonymisation, and tests enforce that rather than trusting it. The dump renders recipe families only - no serial, no settings PIN, no monitor blob - and redacts the user-entered text of the three name families, which is why those blobs are absent rather than scrubbed. Verified in production after the v0.3.20 restart: 184 lines, the four previously-missed recipe types present, the four identifiers excluded, the 11 name blobs redacted to a byte count.

256 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7vRLS5rHkazwsYZRTzVAE