### PR TITLE
fix: the a8f0 lists are a per-profile short list, not the machine's menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,31 @@ All notable changes to this project will be documented in this file.
   blob - and redacts the user-entered text of the three name families, which is
   why those blobs are absent rather than scrubbed.
 
+## [Unreleased]
+
+### Fixed
+- **Correction to a claim shipped in 0.3.20: the `a8f0` lists are not the
+  machine's menu.** The release notes said the reference machine "actually
+  offers" 18 drinks and that three of the buttons shipped for it were therefore
+  fiction. That reading was wrong, and the machine's owner is what disproved it:
+  he can see Doppio+ on the machine's own screen, and its lifetime counter reads
+  **823 brews** - yet it appears in none of the five lists in one dump and in
+  only two of them in another.
+
+  What the lists actually are: a per-profile ordered *short list* of fixed size.
+  Every profile holds exactly 18 entries in every dump, and the contents move -
+  between two dumps of the same machine, profiles 1, 4 and 5 dropped Doppio+ and
+  picked up the bean-system drink, while 2 and 3 kept Doppio+ and never had the
+  bean system. Fixed size with moving contents is a carousel, not a capability
+  list.
+
+  So `on_menu` is now `in_priority_list`, `menu` is `priority_lists`,
+  `menu_position` is `priority_position`, and the docstrings say plainly that
+  membership proves nothing in either direction. No entity or datapoint changes:
+  nothing consumed these fields yet, which is the only reason the wrong reading
+  cost documentation rather than hidden buttons. A test pins the drift between
+  the two dumps so the convenient interpretation cannot come back.
+
 ## [0.3.20] - 2026-09-04
 
 The machine has been publishing its own beverage catalogue all along, in the
@@ -65,9 +90,9 @@ The counters it exposes were also telling two lies, now corrected.
   `0x09`, `0x0f` are 16-bit, everything else 8-bit) consumes **140/140** recipe
   payloads with zero leftover bytes.
 
-  What the machine turns out to publish: which drinks it *actually* offers and in
-  what order, per profile (18 on the reference machine - the integration ships 21
-  buttons for it, so three are fiction); the current quantity of every parameter
+  What the machine turns out to publish: each profile's ordered short list of 18
+  entries (**see the Unreleased correction above - this is a selection, not the
+  set of drinks the machine can make**); the current quantity of every parameter
   of every drink on every profile; the **editable min/default/max ranges** from
   the factory descriptors (hot water 20/250/420 ml, hot milk 50/360/1080); the
   six saved-recipe slots and the bean-system drink, none of which the hardcoded

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Any DeLonghi coffee machine exposed by the Coffee Link mobile app through Ayla N
 - Generic Stop button
 - Services for raw binary command injection (advanced use)
 - Reads the machine's **own recipe catalogue** from the properties it already
-  publishes - which drinks it really offers and in what order per profile, every
-  parameter of every drink on every profile, the editable min/default/max ranges,
-  the saved-recipe slots. Currently used to keep the diagnostics and the
-  learn-and-replay path honest; it creates no entities yet.
+  publishes - every parameter of every drink on every profile, the editable
+  min/default/max ranges the machine itself declares, the saved-recipe slots and
+  the bean-system drink, plus each profile's ordered short list. Currently used
+  to keep the diagnostics and the learn-and-replay path honest; it creates no
+  entities yet.
 
 ### When the machine is unreachable
 

--- a/custom_components/delonghi_coffeelink/catalog.py
+++ b/custom_components/delonghi_coffeelink/catalog.py
@@ -17,7 +17,7 @@ family       n     meaning
 ===========  ====  ==============================================================
 ``b0 f0``    28    factory descriptor - the capability schema (min/default/max)
 ``a6 f0``    140   per-profile instance - the current value of each parameter
-``a8 f0``    5     the machine's own ordered menu, one list per profile
+``a8 f0``    5     a per-profile ordered short list, 18 slots (see below)
 ``a4 f0``    2     profile names (UTF-16BE, user-entered)
 ``aa f0``    2     custom-recipe slot names
 ``ba f0``    7     bean-system names
@@ -27,6 +27,17 @@ The other four are the serial number (``a1 0f``), the machine settings including
 the PIN (``95 0f``), the monitor blob (``75 0f``) and the command-response
 channel (``a9 f0``). They are deliberately out of scope here, and out of the
 diagnostic dump too - see ``command_builder.recipe_dump_lines``.
+
+What the ``a8f0`` lists are NOT: the set of drinks the machine can make. Every
+list is exactly 18 entries long on the reference machine, on all five profiles,
+which makes 18 look like a capacity rather than a count - and the contents move.
+Two dumps of the same machine, days apart, disagree: profiles 1, 4 and 5 dropped
+Doppio+ and gained the bean-system drink, while profiles 2 and 3 kept Doppio+
+and never had the bean system. Doppio+ has been brewed 823 times on that
+machine. So a drink can be absent from all five lists and still be the second
+most-used drink in the household. Treat these lists as an ordered short list per
+profile - a carousel, a favourites row, something of that shape - and never as
+proof that a drink exists or does not.
 
 Two rules make the whole thing parseable without per-beverage special cases:
 
@@ -54,9 +65,10 @@ is missing:
   truncated or missing. Cross-profile disagreement is reported separately as
   ``profiles_differ`` - it is a weaker signal and must not be read as "the user
   changed this".
-* ``on_menu`` is ``None`` for anything the menu blob does not enumerate (custom
-  slots, bean-system), so it can never be used as an existence test against the
-  very entries discovery exists to find.
+* ``in_priority_list`` is never an existence test, for either answer. The
+  ``a8f0`` lists are a per-profile ordered *selection* of fixed size, not the
+  set of drinks the machine can make - see below - so a drink can be missing
+  from every one of them and still be brewed daily.
 """
 from __future__ import annotations
 
@@ -70,7 +82,7 @@ from .const import (
     BLOB_FAMILY_BEAN_NAMES,
     BLOB_FAMILY_CUSTOM_NAMES,
     BLOB_FAMILY_DESCRIPTOR,
-    BLOB_FAMILY_MENU,
+    BLOB_FAMILY_PRIORITY,
     BLOB_FAMILY_PROFILE_NAMES,
     BLOB_FAMILY_PROFILE_RECIPE,
     CMD_RESPONSE_PREFIX,
@@ -83,7 +95,7 @@ BLOB_PREFIX = CMD_RESPONSE_PREFIX
 
 FAMILY_DESCRIPTOR = BLOB_FAMILY_DESCRIPTOR
 FAMILY_PROFILE_RECIPE = BLOB_FAMILY_PROFILE_RECIPE
-FAMILY_MENU = BLOB_FAMILY_MENU
+FAMILY_PRIORITY = BLOB_FAMILY_PRIORITY
 FAMILY_PROFILE_NAMES = BLOB_FAMILY_PROFILE_NAMES
 FAMILY_CUSTOM_NAMES = BLOB_FAMILY_CUSTOM_NAMES
 FAMILY_BEAN_NAMES = BLOB_FAMILY_BEAN_NAMES
@@ -91,7 +103,7 @@ FAMILY_BEAN_NAMES = BLOB_FAMILY_BEAN_NAMES
 FAMILY_LABELS = {
     FAMILY_DESCRIPTOR: "factory_descriptor",
     FAMILY_PROFILE_RECIPE: "profile_recipe",
-    FAMILY_MENU: "menu_order",
+    FAMILY_PRIORITY: "priority_list",
     FAMILY_PROFILE_NAMES: "profile_names",
     FAMILY_CUSTOM_NAMES: "custom_names",
     FAMILY_BEAN_NAMES: "bean_names",
@@ -120,7 +132,7 @@ TAG_INTENSITY = 0x02
 _MIN_PAYLOAD = {
     FAMILY_DESCRIPTOR: 1,
     FAMILY_PROFILE_RECIPE: 2,
-    FAMILY_MENU: 2,
+    FAMILY_PRIORITY: 2,
     FAMILY_PROFILE_NAMES: 2,
     FAMILY_CUSTOM_NAMES: 2,
     FAMILY_BEAN_NAMES: 2,
@@ -323,8 +335,8 @@ def _new_entry(bev_id: int) -> dict:
         "descriptor_truncated": False,
         "ranges": {},
         "profiles": {},
-        "on_menu": None,
-        "menu_position": {},
+        "in_priority_list": None,
+        "priority_position": {},
         "defined": None,
         "profiles_differ": False,
         "off_default": None,
@@ -354,7 +366,7 @@ def build_catalog(props: dict) -> dict:
     caller decides what to do with it; nothing here creates or removes entities.
     """
     beverages: dict[int, dict] = {}
-    menu: dict[int, list[int]] = {}
+    priority: dict[int, list[int]] = {}
     names: dict[str, dict[int, str]] = {"profiles": {}, "custom": {}, "beans": {}}
     stats = {
         "blobs": 0,
@@ -415,9 +427,9 @@ def build_catalog(props: dict) -> dict:
                 stats["unparsed_payloads"] += 1
             else:
                 item["profiles"][profile] = params
-        elif family == FAMILY_MENU:
+        elif family == FAMILY_PRIORITY:
             profile = payload[0]
-            menu[profile] = list(payload[2:])
+            priority[profile] = list(payload[2:])
         elif family in (FAMILY_PROFILE_NAMES, FAMILY_CUSTOM_NAMES, FAMILY_BEAN_NAMES):
             bucket = {
                 FAMILY_PROFILE_NAMES: "profiles",
@@ -430,36 +442,41 @@ def build_catalog(props: dict) -> dict:
             if text:
                 names[bucket][payload[0]] = text
 
-    _apply_menu(beverages, menu)
+    _apply_priority(beverages, priority)
     for item in beverages.values():
         _finalize(item)
 
     return {
         "source": "machine" if beverages else "empty",
         "beverages": beverages,
-        "menu": menu,
+        "priority_lists": priority,
         "names": names,
         "stats": stats,
     }
 
 
-def _apply_menu(beverages: dict[int, dict], menu: dict[int, list[int]]) -> None:
-    """Mark which built-in drinks the machine actually lists in its own menu.
+def _apply_priority(beverages: dict[int, dict], priority: dict[int, list[int]]) -> None:
+    """Record which drinks appear in each profile's ordered short list.
 
-    ``on_menu`` stays ``None`` for custom slots and the bean system: the menu
-    blob enumerates neither, so treating absence as "does not exist" would
-    suppress exactly the entries discovery is for.
+    ``in_priority_list`` says exactly that and nothing more. It is not an
+    existence test in either direction: the lists hold a fixed 18 entries and
+    their contents change over time, so a drink can be absent from all of them
+    and still be brewed daily. Doppio+ is the proof - 823 brews on the reference
+    machine, absent from three of the five lists, and absent from all five in an
+    earlier dump.
+
+    It stays ``None`` where no list was read at all, so "no opinion" and "not
+    selected" never collapse into the same answer.
     """
-    if not menu:
+    if not priority:
         return
-    listed = {bev_id for ids in menu.values() for bev_id in ids}
-    for profile, ids in menu.items():
+    listed = {bev_id for ids in priority.values() for bev_id in ids}
+    for profile, ids in priority.items():
         for position, bev_id in enumerate(ids):
             item = beverages.setdefault(bev_id, _new_entry(bev_id))
-            item["menu_position"][profile] = position
-    for bev_id, item in beverages.items():
-        if item["kind"] == "builtin":
-            item["on_menu"] = bev_id in listed
+            item["priority_position"][profile] = position
+    for item in beverages.values():
+        item["in_priority_list"] = item["id"] in listed
 
 
 def _finalize(item: dict) -> None:
@@ -505,22 +522,22 @@ def catalog_summary(catalog: dict | None) -> str:
         return "no machine catalogue (no readable recipe blobs)"
     beverages = catalog["beverages"]
     stats = catalog["stats"]
-    on_menu = sum(1 for item in beverages.values() if item["on_menu"] is True)
-    off_menu = sum(1 for item in beverages.values() if item["on_menu"] is False)
+    listed = sum(1 for item in beverages.values() if item["in_priority_list"] is True)
+    unlisted = sum(1 for item in beverages.values() if item["in_priority_list"] is False)
     custom = sum(1 for item in beverages.values() if item["kind"] == "custom")
     defined = sum(1 for item in beverages.values() if item["defined"] is True)
     with_ranges = sum(1 for item in beverages.values() if item["ranges"])
-    # "0 on the machine menu" and "the machine published no menu" are different
-    # statements, and only one of them is true when no menu blob was readable.
-    menu_part = (
-        f"{on_menu} on the machine menu, {off_menu} declared but off-menu"
-        if catalog["menu"]
-        else "menu not published"
+    # "0 in a profile short list" and "no short list was published" are
+    # different statements, and only one is true when no a8f0 blob was readable.
+    priority_part = (
+        f"{listed} in a profile short list, {unlisted} in none"
+        if catalog["priority_lists"]
+        else "no profile short list published"
     )
     return (
-        f"{len(beverages)} beverage ids ({menu_part}, "
+        f"{len(beverages)} beverage ids ({priority_part}, "
         f"{custom} custom slots of which {defined} programmed), {with_ranges} with "
-        f"factory min/default/max ranges, {len(catalog['menu'])} profile menus | blobs="
+        f"factory min/default/max ranges, {len(catalog['priority_lists'])} profile lists | blobs="
         f"{stats['blobs']} crc_ok={stats['crc_ok']} crc_failed={stats['crc_failed']} "
         f"truncated={stats['truncated']} unparsed={stats['unparsed_payloads']} "
         f"short={stats['short_payloads']}"

--- a/custom_components/delonghi_coffeelink/const.py
+++ b/custom_components/delonghi_coffeelink/const.py
@@ -66,7 +66,7 @@ CMD_FAMILY_BREW = bytes([0x83, 0xf0])  # Brew beverage command family
 # See catalog.py for the grammar.
 BLOB_FAMILY_DESCRIPTOR = bytes([0xb0, 0xf0])       # factory min/default/max
 BLOB_FAMILY_PROFILE_RECIPE = bytes([0xa6, 0xf0])   # per-profile current values
-BLOB_FAMILY_MENU = bytes([0xa8, 0xf0])             # the machine's ordered menu
+BLOB_FAMILY_PRIORITY = bytes([0xa8, 0xf0])         # per-profile ordered short list
 BLOB_FAMILY_PROFILE_NAMES = bytes([0xa4, 0xf0])
 BLOB_FAMILY_CUSTOM_NAMES = bytes([0xaa, 0xf0])
 BLOB_FAMILY_BEAN_NAMES = bytes([0xba, 0xf0])
@@ -84,7 +84,7 @@ DUMPABLE_BLOB_FAMILIES = frozenset(
     {
         BLOB_FAMILY_DESCRIPTOR,
         BLOB_FAMILY_PROFILE_RECIPE,
-        BLOB_FAMILY_MENU,
+        BLOB_FAMILY_PRIORITY,
         *TEXT_BLOB_FAMILIES,
     }
 )

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -73,7 +73,7 @@ def test_family_census_matches_the_reference_machine(cat: dict):
     families = cat["stats"]["families"]
     assert families["factory_descriptor"] == 28
     assert families["profile_recipe"] == 140  # 28 ids x 5 profiles
-    assert families["menu_order"] == 5  # one ordered menu per profile
+    assert families["priority_list"] == 5  # one ordered menu per profile
     assert families["profile_names"] == 2
     assert families["custom_names"] == 2
     assert families["bean_names"] == 7
@@ -186,39 +186,52 @@ def test_triples_refuse_a_partial_walk():
 # --- what the machine says it can make ------------------------------------- #
 
 
-def test_the_menu_is_the_machines_own_ordered_list(cat: dict):
-    """5 profiles, 18 drinks each, identical set, different order per profile."""
-    menu = cat["menu"]
-    assert sorted(menu) == [1, 2, 3, 4, 5]
-    assert {len(ids) for ids in menu.values()} == {18}
-    sets = [frozenset(ids) for ids in menu.values()]
-    assert len(set(sets)) == 1, "all profiles offer the same drinks"
-    assert len({tuple(ids) for ids in menu.values()}) > 1, "but not in the same order"
+def test_each_profile_has_an_ordered_short_list_of_fixed_size(cat: dict):
+    """5 profiles, 18 entries each, ordered differently.
 
-
-def test_three_drinks_are_declared_but_not_on_the_menu(cat: dict):
-    """The integration currently offers 21 buttons; this machine lists 18.
-
-    long_black, mug_to_go and brew_over_ice have recipe slots from the shared
-    firmware template and lifetime counters stuck at 0, but the machine never
-    lists them - so three of the buttons we ship for it are fiction.
+    18 on every profile of every dump is what makes it look like a capacity
+    rather than a count - see the drift test below.
     """
-    off_menu = {i for i, item in cat["beverages"].items() if item["on_menu"] is False}
-    assert off_menu == {0x19, 0x1A, 0x1B}
-    on_menu = [i for i, item in cat["beverages"].items() if item["on_menu"] is True]
-    assert len(on_menu) == 18
+    priority = cat["priority_lists"]
+    assert sorted(priority) == [1, 2, 3, 4, 5]
+    assert {len(ids) for ids in priority.values()} == {18}
+    assert len({tuple(ids) for ids in priority.values()}) > 1, "ordered differently"
 
 
-def test_on_menu_is_unknown_for_slots_the_menu_does_not_enumerate(cat: dict):
-    """``on_menu`` must never be an existence test for custom or bean slots.
+def test_being_in_no_short_list_does_not_mean_the_drink_is_unavailable(cat: dict):
+    """The correction that cost the most to learn, pinned so it cannot come back.
 
-    The menu blob lists only built-in ids, so reading "absent from the menu" as
-    "does not exist" would suppress precisely the entries discovery is for.
+    long_black, mug_to_go and brew_over_ice sit in none of the five lists, and it
+    would be easy to read that as "this machine cannot make them" and hide their
+    buttons. Doppio+ is the counter-example that forbids it: absent from three of
+    the five lists in the production dump, absent from all five in this one, and
+    brewed 823 times on the very same machine.
     """
-    for bev_id in list(catalog.CUSTOM_SLOT_IDS) + [0xC8]:
-        item = cat["beverages"].get(bev_id)
-        if item is not None:
-            assert item["on_menu"] is None
+    unlisted = {i for i, item in cat["beverages"].items() if item["in_priority_list"] is False}
+    assert {0x19, 0x1A, 0x1B} <= unlisted
+    listed = [i for i, item in cat["beverages"].items() if item["in_priority_list"] is True]
+    assert len(listed) == 18
+
+
+def test_in_priority_list_is_unknown_only_when_no_list_was_read():
+    """"Not selected" and "no opinion" must stay distinguishable.
+
+    Every drink gets a definite True/False once any list is read, including the
+    custom slots and the bean system that no list enumerates - the flag reports
+    membership, and membership of an unread list is what `None` is for.
+    """
+    descriptor = _blob(catalog.FAMILY_DESCRIPTOR, bytes([0x10, catalog.TAG_WATER_ML, 0, 20, 0, 250, 1, 164]))
+    without = catalog.build_catalog({"d015_rec_hot_water": {"value": descriptor}})
+    assert without["beverages"][0x10]["in_priority_list"] is None
+
+    with_list = catalog.build_catalog(
+        {
+            "d015_rec_hot_water": {"value": descriptor},
+            "d261_1_rec_priority": {"value": _blob(catalog.FAMILY_PRIORITY, bytes([1, 0xC8, 0x07]))},
+        }
+    )
+    assert with_list["beverages"][0x10]["in_priority_list"] is False
+    assert with_list["beverages"][0x07]["in_priority_list"] is True
 
 
 def test_custom_slots_are_found_and_reported_as_unprogrammed(cat: dict):
@@ -377,7 +390,7 @@ def test_summary_reports_what_was_unreadable(cat: dict):
     """The diagnostic line must show the truncation, not hide it."""
     summary = catalog.catalog_summary(cat)
     assert "28 beverage ids" in summary
-    assert "18 on the machine menu" in summary
+    assert "in a profile short list" in summary
     assert "truncated=31" in summary
 
 
@@ -431,7 +444,7 @@ def test_a_blob_too_short_for_its_own_header_is_refused():
     for family in (
         catalog.FAMILY_DESCRIPTOR,
         catalog.FAMILY_PROFILE_RECIPE,
-        catalog.FAMILY_MENU,
+        catalog.FAMILY_PRIORITY,
         catalog.FAMILY_BEAN_NAMES,
     ):
         blob = _blob(family, b"")
@@ -441,12 +454,12 @@ def test_a_blob_too_short_for_its_own_header_is_refused():
         assert cat["beverages"] == {}
 
 
-def test_a_menu_entry_without_a_recipe_is_listed_but_not_declared():
-    """On the menu, yet no descriptor: exists for the user, not learnable."""
-    blob = _blob(catalog.FAMILY_MENU, bytes([1, 0xC8, 0x07]))
+def test_a_listed_entry_without_a_recipe_is_listed_but_not_declared():
+    """In a short list, yet no descriptor: worth showing, not worth learning."""
+    blob = _blob(catalog.FAMILY_PRIORITY, bytes([1, 0xC8, 0x07]))
     cat = catalog.build_catalog({"d261_1_rec_priority": {"value": blob}})
     entry = cat["beverages"][0x07]
-    assert entry["on_menu"] is True
+    assert entry["in_priority_list"] is True
     assert entry["declared"] is False
     assert catalog.catalog_beverage_ids(cat) == set()
 
@@ -531,13 +544,13 @@ def test_profiles_differ_is_asserted_both_ways(cat: dict):
     assert catalog.build_catalog(same)["beverages"][0x01]["profiles_differ"] is False
 
 
-def test_on_menu_is_unknown_when_no_menu_blob_was_read():
-    """No menu blob means no opinion - never "not on the menu"."""
+def test_the_summary_says_unpublished_rather_than_zero():
+    """No a8f0 blob means no opinion, and the summary must not imply zero."""
     payload = bytes([0x10, catalog.TAG_WATER_ML, 0, 20, 0, 250, 1, 164])
     cat = catalog.build_catalog({"d015_rec_hot_water": {"value": _blob(catalog.FAMILY_DESCRIPTOR, payload)}})
-    assert cat["beverages"][0x10]["on_menu"] is None
-    assert cat["menu"] == {}
-    assert "0 on the machine menu" not in catalog.catalog_summary(cat)
+    assert cat["beverages"][0x10]["in_priority_list"] is None
+    assert cat["priority_lists"] == {}
+    assert "no profile short list published" in catalog.catalog_summary(cat)
 
 
 def test_an_unparsable_payload_is_counted_and_never_half_parsed():
@@ -598,9 +611,9 @@ def test_name_blobs_are_filed_by_family_and_slot():
 def test_summary_reports_every_counter(cat: dict):
     """Spot-checking three substrings let the other five counters mutate freely."""
     assert catalog.catalog_summary(cat) == (
-        "28 beverage ids (18 on the machine menu, 3 declared but off-menu, "
+        "28 beverage ids (18 in a profile short list, 10 in none, "
         "6 custom slots of which 0 programmed), 8 with factory min/default/max "
-        "ranges, 5 profile menus | blobs=194 crc_ok=163 crc_failed=0 "
+        "ranges, 5 profile lists | blobs=194 crc_ok=163 crc_failed=0 "
         "truncated=31 unparsed=0 short=0"
     )
 
@@ -659,7 +672,7 @@ def test_the_fingerprint_normalises_whitespace_like_the_parser(props: dict):
 
 def test_blob_family_reads_the_family_without_a_full_decode(props: dict):
     assert catalog.blob_family(props["d039_1_rec_espresso"]["value"]) == catalog.FAMILY_PROFILE_RECIPE
-    assert catalog.blob_family(props["d261_1_rec_priority"]["value"]) == catalog.FAMILY_MENU
+    assert catalog.blob_family(props["d261_1_rec_priority"]["value"]) == catalog.FAMILY_PRIORITY
     assert catalog.blob_family(props["d270_serialnumber"]["value"]) == b"\xa1\x0f"
     for not_a_blob in (None, "", "AA==", "not base64 !!", 42, "QUJDRA=="):
         assert catalog.blob_family(not_a_blob) is None
@@ -773,7 +786,7 @@ def test_the_recipe_fixture_needs_no_anonymisation(full_props: dict):
     assert families <= {
         catalog.FAMILY_DESCRIPTOR,
         catalog.FAMILY_PROFILE_RECIPE,
-        catalog.FAMILY_MENU,
+        catalog.FAMILY_PRIORITY,
     }, "a text-bearing family would need the anonymiser"
 
 
@@ -809,4 +822,27 @@ def test_the_bean_system_drink_carries_a_real_schema(full_cat: dict):
     assert bean["ranges"][catalog.TAG_COFFEE_ML] == (30, 40, 60)
     assert bean["ranges"][catalog.TAG_INTENSITY] == (1, 4, 5)
     assert len(bean["profiles"]) == 5, "one per-profile recipe per profile"
-    assert bean["on_menu"] is None, "the menu blob does not enumerate it"
+    assert bean["in_priority_list"] is True, "it is in three of the five lists"
+
+
+def test_the_short_lists_drift_between_two_dumps_of_one_machine(cat: dict, full_cat: dict):
+    """The evidence that 18 is a capacity and the lists are a selection.
+
+    Same machine, two dumps. Both times every profile holds exactly 18 entries.
+    But profiles 1, 4 and 5 swapped Doppio+ out for the bean-system drink between
+    them, while 2 and 3 kept Doppio+ and never carried the bean system.
+
+    A fixed size with moving contents is what a carousel looks like, not what a
+    capability list looks like - which is why nothing in this module treats
+    membership as proof that a drink exists.
+    """
+    assert {len(ids) for ids in cat["priority_lists"].values()} == {18}
+    assert {len(ids) for ids in full_cat["priority_lists"].values()} == {18}
+
+    def profiles_holding(catalogue: dict, bev_id: int) -> set:
+        return set(catalogue["beverages"][bev_id]["priority_position"])
+
+    assert profiles_holding(cat, 0x05) == {1, 2, 3, 4, 5}, "Doppio+ was on every list"
+    assert profiles_holding(full_cat, 0x05) == {2, 3}, "and later on only two"
+    assert profiles_holding(cat, 0xC8) == set(), "the bean system was on none"
+    assert profiles_holding(full_cat, 0xC8) == {1, 4, 5}, "and later took the free slots"


### PR DESCRIPTION
0.3.20's notes said the reference machine "actually offers" 18 drinks, and that three of the 21 buttons shipped for it were therefore fiction. **That was wrong.**

The machine's owner disproved it in one sentence: he can see Doppio+ on the machine's own screen. Its lifetime counter reads **823 brews** - the second most-used drink in the household - and it appears in **none** of the five lists in one dump, and in only two of them in another.

### What the lists actually are

A per-profile ordered **short list of fixed size**. Every profile holds exactly 18 entries in every dump, and the contents move:

| | Doppio+ (823 brews) | bean system |
|---|---|---|
| earlier dump | all 5 profiles | no profile |
| production dump | profiles 2, 3 | profiles 1, 4, 5 |

Fixed size with moving contents is a carousel, not a capability list. Profiles 1, 4 and 5 swapped one out for the other, which is only possible if 18 is a capacity.

### The change

`on_menu` becomes `in_priority_list`, `menu` becomes `priority_lists`, `menu_position` becomes `priority_position`, `BLOB_FAMILY_MENU` becomes `BLOB_FAMILY_PRIORITY`, and the docstrings say plainly that membership proves nothing in either direction.

The flag is now computed for every id rather than built-ins only. It reports list membership, and the previous `None`-for-custom-slots was working around a meaning the field should never have had - `None` now means only "no list was read".

**No entity, datapoint or stored value changes.** Nothing consumed these fields yet, which is the only reason a wrong reading cost documentation rather than hidden buttons. Hiding those three drinks is exactly what the old wording invited.

### Tests

The assertion that all profiles carry the same ids is **gone**: it held on one dump and is false on the next, which is the definition of a test that pins a coincidence. In its place, one test pins the drift between the two dumps, and one pins that being in no short list is not evidence a drink is unavailable.

257 pass, ruff clean. Three mutations of the new logic were each caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7vRLS5rHkazwsYZRTzVAE