### PR TITLE
chore(release): v0.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.3.21] - 2026-09-05
 
 ### Fixed
 - **PrimaDonna Soul: Machine Status no longer freezes (#14).** The Soul publishes

--- a/custom_components/delonghi_coffeelink/manifest.json
+++ b/custom_components/delonghi_coffeelink/manifest.json
@@ -14,5 +14,5 @@
     "custom_components.delonghi_coffeelink"
   ],
   "requirements": [],
-  "version": "0.3.20"
+  "version": "0.3.21"
 }


### PR DESCRIPTION
Closes the Unreleased section and bumps the manifest so HACS offers the fix.

The headline is #14: on a PrimaDonna Soul the status sensor could report a value days old while every other sign said healthy. Also carries the catalogue corrections found while validating against a second live machine.

Patch rather than minor: no entity_id changes, no breaking API, 0.4.0 stays reserved for the LAN work.

270 tests pass, ruff clean.