### PR TITLE
fix: the priority-list payload has no header byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,27 +46,36 @@ All notable changes to this project will be documented in this file.
     unknown-model fallback: same command dialect, which does generalise, without
     the keepalive, which does not.
 
-- **Correction to a claim shipped in 0.3.20: the `a8f0` lists are not the
-  machine's menu.** The release notes said the reference machine "actually
-  offers" 18 drinks and that three of the buttons shipped for it were therefore
-  fiction. That reading was wrong, and the machine's owner is what disproved it:
-  he can see Doppio+ on the machine's own screen, and its lifetime counter reads
-  **823 brews** - yet it appears in none of the five lists in one dump and in
-  only two of them in another.
+- **The `a8f0` priority lists were parsed one byte short, and the correction
+  that renamed them rested on that mistake.** Two rounds on the same three
+  frames, so both are worth recording.
 
-  What the lists actually are: a per-profile ordered *short list* of fixed size.
-  Every profile holds exactly 18 entries in every dump, and the contents move -
-  between two dumps of the same machine, profiles 1, 4 and 5 dropped Doppio+ and
-  picked up the bean-system drink, while 2 and 3 kept Doppio+ and never had the
-  bean system. Fixed size with moving contents is a carousel, not a capability
-  list.
+  0.3.20 called these lists the machine's menu and concluded that three of the
+  buttons shipped for the reference machine were fiction. The machine's owner
+  disproved it by looking at the machine: Doppio+ is on its screen and has a
+  lifetime counter well into the hundreds, yet the parser placed it in no list.
+  Hence the rename to `in_priority_list` / `priority_lists` /
+  `priority_position`, and the rule that membership proves nothing either way.
 
-  So `on_menu` is now `in_priority_list`, `menu` is `priority_lists`,
-  `menu_position` is `priority_position`, and the docstrings say plainly that
-  membership proves nothing in either direction. No entity or datapoint changes:
-  nothing consumed these fields yet, which is the only reason the wrong reading
-  cost documentation rather than hidden buttons. A test pins the drift between
-  the two dumps so the convenient interpretation cannot come back.
+  That rule stands. Its stated evidence does not. The payload is
+  `<profile> <bevid...>` with **no header byte**, and the parser read the ids
+  from `payload[2:]`, eating each list's first entry. Decoding the raw frames:
+  every list is 19 entries, not 18, and all ten (five profiles, two dumps)
+  carry one identical set of ids. The reported "contents move between dumps"
+  was the off-by-one; what actually differs is the order, by two adjacent
+  transpositions on three profiles - a most-recently-used ordering. The
+  bean-system drink was reported as absent from every list while the machine
+  puts it **first on all five**.
+
+  Membership still is not an existence test, and now for a reason that survives
+  checking: `0x19`, `0x1a` and `0x1b` each have a factory descriptor, a recipe
+  on every profile and a lifetime counter, and appear in no list at all.
+
+  No entity or datapoint changes - nothing consumes these fields yet, which is
+  the only reason two wrong readings cost documentation rather than hidden
+  buttons. The tests that pinned the artefact have been replaced by ones that
+  fail if the first entry is ever dropped again, including the one-entry list
+  that the old `_MIN_PAYLOAD` of 2 would have parsed as empty.
 
 ### Changed
 - **`_slot_is_defined` no longer checks the `0xff` intensity marker.** A slot

--- a/custom_components/delonghi_coffeelink/catalog.py
+++ b/custom_components/delonghi_coffeelink/catalog.py
@@ -17,7 +17,7 @@ family       n     meaning
 ===========  ====  ==============================================================
 ``b0 f0``    28    factory descriptor - the capability schema (min/default/max)
 ``a6 f0``    140   per-profile instance - the current value of each parameter
-``a8 f0``    5     a per-profile ordered short list, 18 slots (see below)
+``a8 f0``    5     a per-profile ordered short list of beverage ids
 ``a4 f0``    2     profile names (UTF-16BE, user-entered)
 ``aa f0``    2     custom-recipe slot names
 ``ba f0``    7     bean-system names
@@ -28,16 +28,22 @@ the PIN (``95 0f``), the monitor blob (``75 0f``) and the command-response
 channel (``a9 f0``). They are deliberately out of scope here, and out of the
 diagnostic dump too - see ``command_builder.recipe_dump_lines``.
 
-What the ``a8f0`` lists are NOT: the set of drinks the machine can make. Every
-list is exactly 18 entries long on the reference machine, on all five profiles,
-which makes 18 look like a capacity rather than a count - and the contents move.
-Two dumps of the same machine, days apart, disagree: profiles 1, 4 and 5 dropped
-Doppio+ and gained the bean-system drink, while profiles 2 and 3 kept Doppio+
-and never had the bean system. Doppio+ has been brewed 823 times on that
-machine. So a drink can be absent from all five lists and still be the second
-most-used drink in the household. Treat these lists as an ordered short list per
-profile - a carousel, a favourites row, something of that shape - and never as
-proof that a drink exists or does not.
+What the ``a8f0`` lists are NOT: the set of drinks the machine can make. On the
+reference machine all ten lists (five profiles, two dumps taken days apart)
+carry one identical set of 19 ids in four different orders, and between the two
+dumps profiles 1, 4 and 5 changed order only - two adjacent transpositions each,
+which is what a recency ordering looks like. Meanwhile three drinks that have
+factory descriptors, per-profile recipes and lifetime counters (``0x19``
+long_black, ``0x1a`` mug_to_go, ``0x1b`` brew_over_ice) appear in no list at
+all. So membership is not evidence in either direction: it is an ordered short
+list per profile, and a drink can be missing from every one of them and still be
+brewable.
+
+That caution is not theoretical. An earlier version of this parser read the ids
+from ``payload[2:]``, assuming a header byte the frames do not have, and so ate
+each list's first entry. It reported the bean-system drink as absent from every
+list when the machine puts it first on all five, and the resulting "the contents
+move between dumps" was an artefact of the off-by-one rather than a finding.
 
 Two rules make the whole thing parseable without per-beverage special cases:
 
@@ -132,7 +138,7 @@ TAG_INTENSITY = 0x02
 _MIN_PAYLOAD = {
     FAMILY_DESCRIPTOR: 1,
     FAMILY_PROFILE_RECIPE: 2,
-    FAMILY_PRIORITY: 2,
+    FAMILY_PRIORITY: 1,  # <profile>, then ids; a one-entry list is 2 bytes
     FAMILY_PROFILE_NAMES: 2,
     FAMILY_CUSTOM_NAMES: 2,
     FAMILY_BEAN_NAMES: 2,
@@ -428,8 +434,11 @@ def build_catalog(props: dict) -> dict:
             else:
                 item["profiles"][profile] = params
         elif family == FAMILY_PRIORITY:
+            # payload = <profile> <bevid...>. There is NO header byte after the
+            # profile: every remaining byte is a beverage id. Reading from [2:]
+            # silently ate each list's first entry - see the module docstring.
             profile = payload[0]
-            priority[profile] = list(payload[2:])
+            priority[profile] = list(payload[1:])
         elif family in (FAMILY_PROFILE_NAMES, FAMILY_CUSTOM_NAMES, FAMILY_BEAN_NAMES):
             bucket = {
                 FAMILY_PROFILE_NAMES: "profiles",
@@ -459,11 +468,10 @@ def _apply_priority(beverages: dict[int, dict], priority: dict[int, list[int]]) 
     """Record which drinks appear in each profile's ordered short list.
 
     ``in_priority_list`` says exactly that and nothing more. It is not an
-    existence test in either direction: the lists hold a fixed 18 entries and
-    their contents change over time, so a drink can be absent from all of them
-    and still be brewed daily. Doppio+ is the proof - 823 brews on the reference
-    machine, absent from three of the five lists, and absent from all five in an
-    earlier dump.
+    existence test in either direction: ``0x19``, ``0x1a`` and ``0x1b`` have
+    factory descriptors, per-profile recipes and lifetime counters on the
+    reference machine and appear in none of its five lists, so absence proves
+    nothing about what the machine can brew.
 
     It stays ``None`` where no list was read at all, so "no opinion" and "not
     selected" never collapse into the same answer.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -186,16 +186,31 @@ def test_triples_refuse_a_partial_walk():
 # --- what the machine says it can make ------------------------------------- #
 
 
-def test_each_profile_has_an_ordered_short_list_of_fixed_size(cat: dict):
-    """5 profiles, 18 entries each, ordered differently.
+def test_every_byte_after_the_profile_is_a_beverage_id(cat: dict, full_cat: dict):
+    """The off-by-one this file now exists to prevent.
 
-    18 on every profile of every dump is what makes it look like a capacity
-    rather than a count - see the drift test below.
+    The payload is `<profile> <bevid...>` with NO header byte, so reading the
+    ids from `payload[2:]` eats each list's first entry. That shipped once: it
+    reported the bean-system drink as absent from every list when the machine
+    puts it first on all five, and it manufactured a "the contents drift between
+    dumps" finding out of nothing.
+
+    Two independent guards, because a length assertion alone would pass a parser
+    that dropped the first id and gained a phantom at the end.
     """
-    priority = cat["priority_lists"]
-    assert sorted(priority) == [1, 2, 3, 4, 5]
-    assert {len(ids) for ids in priority.values()} == {18}
-    assert len({tuple(ids) for ids in priority.values()}) > 1, "ordered differently"
+    for catalogue in (cat, full_cat):
+        priority = catalogue["priority_lists"]
+        assert sorted(priority) == [1, 2, 3, 4, 5]
+        assert {len(ids) for ids in priority.values()} == {19}
+        # Every entry is an id the machine also declares elsewhere. A stray
+        # header byte would not satisfy this.
+        declared = catalog.catalog_beverage_ids(catalogue)
+        for ids in priority.values():
+            assert set(ids) <= declared, "a list entry that no descriptor declares"
+
+    # And the one that pins the boundary directly: the bean system leads every
+    # list on the reference machine, which is exactly the byte an off-by-one eats.
+    assert cat["beverages"][0xC8]["priority_position"] == {1: 0, 2: 0, 3: 0, 4: 0, 5: 0}
 
 
 def test_being_in_no_short_list_does_not_mean_the_drink_is_unavailable(cat: dict):
@@ -203,14 +218,18 @@ def test_being_in_no_short_list_does_not_mean_the_drink_is_unavailable(cat: dict
 
     long_black, mug_to_go and brew_over_ice sit in none of the five lists, and it
     would be easy to read that as "this machine cannot make them" and hide their
-    buttons. Doppio+ is the counter-example that forbids it: absent from three of
-    the five lists in the production dump, absent from all five in this one, and
-    brewed 823 times on the very same machine.
+    buttons. They are the counter-example to that reading: all three carry a
+    factory descriptor, a recipe on every profile and a lifetime counter, so the
+    machine plainly knows them. Membership is an ordering, not a capability.
     """
     unlisted = {i for i, item in cat["beverages"].items() if item["in_priority_list"] is False}
     assert {0x19, 0x1A, 0x1B} <= unlisted
+    for bev_id in (0x19, 0x1A, 0x1B):
+        item = cat["beverages"][bev_id]
+        assert item["declared"] is True, "the machine carries a factory descriptor for it"
+        assert item["profiles"], "and a recipe on every profile"
     listed = [i for i, item in cat["beverages"].items() if item["in_priority_list"] is True]
-    assert len(listed) == 18
+    assert len(listed) == 19
 
 
 def test_in_priority_list_is_unknown_only_when_no_list_was_read():
@@ -611,7 +630,7 @@ def test_name_blobs_are_filed_by_family_and_slot():
 def test_summary_reports_every_counter(cat: dict):
     """Spot-checking three substrings let the other five counters mutate freely."""
     assert catalog.catalog_summary(cat) == (
-        "28 beverage ids (18 in a profile short list, 10 in none, "
+        "28 beverage ids (19 in a profile short list, 9 in none, "
         "6 custom slots of which 0 programmed), 8 with factory min/default/max "
         "ranges, 5 profile lists | blobs=194 crc_ok=163 crc_failed=0 "
         "truncated=31 unparsed=0 short=0"
@@ -825,24 +844,52 @@ def test_the_bean_system_drink_carries_a_real_schema(full_cat: dict):
     assert bean["in_priority_list"] is True, "it is in three of the five lists"
 
 
-def test_the_short_lists_drift_between_two_dumps_of_one_machine(cat: dict, full_cat: dict):
-    """The evidence that 18 is a capacity and the lists are a selection.
+def test_the_lists_reorder_between_dumps_but_never_change_membership(cat: dict, full_cat: dict):
+    """What actually moves between two dumps of one machine: the order, only.
 
-    Same machine, two dumps. Both times every profile holds exactly 18 entries.
-    But profiles 1, 4 and 5 swapped Doppio+ out for the bean-system drink between
-    them, while 2 and 3 kept Doppio+ and never carried the bean system.
-
-    A fixed size with moving contents is what a carousel looks like, not what a
-    capability list looks like - which is why nothing in this module treats
-    membership as proof that a drink exists.
+    This test previously asserted the opposite - that membership drifted - and
+    it passed, because the parser was eating each list's first entry and
+    manufacturing the difference. All ten lists carry the same 19 ids; profiles
+    1, 4 and 5 differ between the dumps by two adjacent transpositions each,
+    which is what a most-recently-used ordering looks like.
     """
-    assert {len(ids) for ids in cat["priority_lists"].values()} == {18}
-    assert {len(ids) for ids in full_cat["priority_lists"].values()} == {18}
+    sets = [frozenset(ids) for ids in cat["priority_lists"].values()]
+    sets += [frozenset(ids) for ids in full_cat["priority_lists"].values()]
+    assert len(set(sets)) == 1, "one membership set across ten lists"
+    assert len(sets[0]) == 19
 
-    def profiles_holding(catalogue: dict, bev_id: int) -> set:
-        return set(catalogue["beverages"][bev_id]["priority_position"])
+    def order(catalogue: dict, profile: int) -> list:
+        return catalogue["priority_lists"][profile]
 
-    assert profiles_holding(cat, 0x05) == {1, 2, 3, 4, 5}, "Doppio+ was on every list"
-    assert profiles_holding(full_cat, 0x05) == {2, 3}, "and later on only two"
-    assert profiles_holding(cat, 0xC8) == set(), "the bean system was on none"
-    assert profiles_holding(full_cat, 0xC8) == {1, 4, 5}, "and later took the free slots"
+    for profile in (2, 3):
+        assert order(cat, profile) == order(full_cat, profile), "these two never moved"
+    for profile in (1, 4, 5):
+        before, after = order(cat, profile), order(full_cat, profile)
+        assert before != after, "these reordered"
+        assert sorted(before) == sorted(after), "without gaining or losing a drink"
+        moved = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+        assert moved == [0, 1, 4, 5], "two adjacent swaps, nothing else"
+
+
+def test_a_single_entry_list_is_read_not_discarded():
+    """The smallest possible list: one profile byte, one beverage id.
+
+    `_MIN_PAYLOAD[FAMILY_PRIORITY]` has to be 1, not 2. At 2 this frame clears
+    the guard and then parses to an empty list, which reports a confident "not
+    selected" for the only drink the machine selected - the exact shape of lie
+    this module exists to avoid.
+    """
+    blob = _blob(catalog.FAMILY_PRIORITY, bytes([1, 0x07]))
+    cat = catalog.build_catalog({"d261_1_rec_priority": {"value": blob}})
+    assert cat["priority_lists"] == {1: [0x07]}
+    assert cat["beverages"][0x07]["in_priority_list"] is True
+    assert cat["stats"]["short_payloads"] == 0
+    assert "1 in a profile short list" in catalog.catalog_summary(cat)
+
+
+def test_a_priority_blob_with_no_ids_at_all_is_refused():
+    """A profile byte and nothing else says nothing, so it must not say "none"."""
+    blob = _blob(catalog.FAMILY_PRIORITY, bytes([1]))
+    cat = catalog.build_catalog({"d261_1_rec_priority": {"value": blob}})
+    assert cat["priority_lists"] == {1: []}
+    assert cat["stats"]["short_payloads"] == 0


### PR DESCRIPTION
`payload = <profile> <bevid...>`, and the parser read the ids from `payload[2:]`, eating each list's first entry.

Decoding the raw `a8f0` frames from both fixtures by hand:

```
d261_1 profile=0x01 then 19 bytes: c8 05 08 07 03 06 0c 10 04 16 01 0b 17 02 09 0a 0d 0f 18
```

Every list is **19** entries, not 18, and all ten (five profiles, two dumps) carry **one identical set of ids**.

### What that broke

The bean-system drink `0xc8` leads every list on the reference machine, so it was reported as **absent from all five** while the machine puts it **first on all five**, with every other id one position out. That line goes out at INFO on the first poll of every install and heads the `Dump Recipe Datapoints` block the README tells users to paste into public issues.

Worse in the general case: a machine with a one-entry list cleared `_MIN_PAYLOAD` of 2 and then parsed to an empty list, reporting a confident *not selected* for the only drink the machine had selected. In a module whose stated contract is that unknown must never read as no.

### And the evidence for 0.3.21's rename was the artefact

0.3.21 renamed `on_menu` to `in_priority_list` on the strength of "the contents move between dumps". They do not. What differs is the **order**, by two adjacent transpositions on profiles 1, 4 and 5 - a most-recently-used ordering. I was watching `0xc8` "appear" because it sits at position 0, the byte the off-by-one ate.

**The conclusion survives, on different grounds.** Membership is still not an existence test, because `0x19`, `0x1a` and `0x1b` each carry a factory descriptor, a per-profile recipe and a lifetime counter, and appear in no list at all. The docstrings and CHANGELOG now say that instead.

### Tests

Four tests pinned the artefact - including one that asserted the drift I had invented - and are replaced by tests that fail if the first entry is ever dropped again:

- every list entry must be an id the machine declares elsewhere, which a stray header byte could not satisfy
- the bean system at position 0 on all five profiles, the exact byte an off-by-one eats
- the two dumps reorder without changing membership, asserted as two adjacent swaps
- a one-entry list parses to one entry, not zero

272 pass, ruff clean. Three mutations caught, including a return to the original bug.

### How it was found

Not by a field report - by auditing the shipped diff against the project directives, after the maintainer asked whether everything shipped actually complied. Nothing consumes these fields yet, which is the only reason two successive wrong readings cost documentation rather than hidden buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7vRLS5rHkazwsYZRTzVAE