### PR TITLE
fix: a dropped connection must not read as every button being pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
+- **A dropped connection no longer reads as every button being pressed.** One
+  Ayla 504 took the whole platform unavailable; 30 s later the next poll
+  succeeded and the buttons returned to `unknown`. The logbook drew that as
+  every button on the machine being pressed in the same second, because it
+  labels *every* state change of a `button` entity "Pressed" - there is no
+  other word for the domain (frontend `src/data/logbook.ts`,
+  `STATE_ACTION_MESSAGES`). Nothing was sent to the machine, but a `state`
+  trigger watching a button did fire, so an automation keyed on one could act
+  on a cloud hiccup.
+
+  Buttons no longer follow the coordinator's availability. A button has no state
+  of its own to lose - its state is the timestamp of the last press - so taking
+  it unavailable bought nothing and cost the false entry. Whether a command can
+  actually reach the machine was never this flag's job: the coordinator
+  preflight still refuses to write to a machine the cloud reports Offline, and
+  raises an error the user sees. Connection health remains on the Connection and
+  Machine Status sensors, which is where it is readable.
+
 - **Every Ayla call is now bounded by a 30 s timeout, and a timeout is now
   retried like any other transient failure.** The session comes from Home
   Assistant, which inherits aiohttp's 300 s default - not unbounded, but far too

--- a/custom_components/delonghi_coffeelink/button.py
+++ b/custom_components/delonghi_coffeelink/button.py
@@ -38,6 +38,27 @@ class _Base(CoordinatorEntity[DelonghiCoordinator], ButtonEntity):
     _attr_has_entity_name = True
 
     @property
+    def available(self) -> bool:
+        """Buttons stay available across a failed poll - on purpose.
+
+        A button has no state of its own to lose: its state is the timestamp of
+        the last press, and `unknown` until one happens. Letting the coordinator
+        take it unavailable therefore buys no information, and costs a real bug.
+        The logbook labels *every* state change of a `button` entity "Pressed"
+        (frontend `src/data/logbook.ts`, STATE_ACTION_MESSAGES), so the trip
+        through `unavailable` and back after any cloud hiccup was rendered as
+        every button on the machine being pressed in the same second, and fired
+        every `state` trigger watching them. Observed on a single Ayla 504.
+
+        Refusing a command to a machine that cannot receive it is the
+        coordinator preflight's job (`_ensure_machine_reachable`), which raises
+        with an error the user actually sees. That check reads the machine's
+        connection status, not our poll health, so nothing is lost by keeping
+        the buttons pressable here.
+        """
+        return True
+
+    @property
     def device_info(self) -> DeviceInfo:
         d = self.coordinator.device
         return DeviceInfo(

--- a/tests/test_coordinator_session.py
+++ b/tests/test_coordinator_session.py
@@ -60,6 +60,8 @@ class _StubCoordinator:
         self.name = name
         self.update_interval = update_interval
         self.data: dict | None = None
+        # What CoordinatorEntity.available reads; a failed poll clears it.
+        self.last_update_success = True
 
     def __class_getitem__(cls, item):  # DataUpdateCoordinator[dict[str, Any]]
         return cls
@@ -82,6 +84,31 @@ class _StubHomeAssistantError(Exception):
         self.translation_placeholders = translation_placeholders
 
 
+class _StubCoordinatorEntity:
+    """helpers.update_coordinator.CoordinatorEntity.
+
+    Only the part under test is reproduced: HA's own class ties `available` to
+    the coordinator's last poll, which is exactly what button.py overrides.
+    """
+
+    def __init__(self, coordinator, context=None) -> None:
+        self.coordinator = coordinator
+
+    def __class_getitem__(cls, item):  # CoordinatorEntity[DelonghiCoordinator]
+        return cls
+
+    @property
+    def available(self) -> bool:
+        return self.coordinator.last_update_success
+
+
+class _StubButtonEntity:
+    """components.button.ButtonEntity - a bare base; the _attr_* are plain."""
+
+    _attr_has_entity_name = False
+    name = None  # Entity.name, read by the press-time log line
+
+
 def _install_stubs() -> None:
     core = types.ModuleType("homeassistant.core")
     core.HomeAssistant = object
@@ -91,12 +118,30 @@ def _install_stubs() -> None:
     storage.Store = _StubStore
     upd = types.ModuleType("homeassistant.helpers.update_coordinator")
     upd.DataUpdateCoordinator = _StubCoordinator
+    upd.CoordinatorEntity = _StubCoordinatorEntity
     upd.UpdateFailed = type("UpdateFailed", (Exception,), {})
+    # The entity platforms: button.py is loaded here too, so its imports resolve.
+    button_mod = types.ModuleType("homeassistant.components.button")
+    button_mod.ButtonEntity = _StubButtonEntity
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    config_entries.ConfigEntry = object
+    ha_const = types.ModuleType("homeassistant.const")
+    ha_const.EntityCategory = types.SimpleNamespace(DIAGNOSTIC="diagnostic")
+    device_registry = types.ModuleType("homeassistant.helpers.device_registry")
+    device_registry.DeviceInfo = dict
+    entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+    entity_platform.AddEntitiesCallback = object
     for name, mod in (
         ("homeassistant", types.ModuleType("homeassistant")),
+        ("homeassistant.components", types.ModuleType("homeassistant.components")),
+        ("homeassistant.components.button", button_mod),
+        ("homeassistant.config_entries", config_entries),
+        ("homeassistant.const", ha_const),
         ("homeassistant.core", core),
         ("homeassistant.exceptions", exceptions),
         ("homeassistant.helpers", types.ModuleType("homeassistant.helpers")),
+        ("homeassistant.helpers.device_registry", device_registry),
+        ("homeassistant.helpers.entity_platform", entity_platform),
         ("homeassistant.helpers.storage", storage),
         ("homeassistant.helpers.update_coordinator", upd),
     ):
@@ -125,6 +170,7 @@ const = _load("const", "const.py")
 cb = _load("command_builder", "command_builder.py")
 ac = _load("ayla_client", "ayla_client.py")
 coordinator = _load("coordinator", "coordinator.py")
+button = _load("button", "button.py")
 
 COFFEE_FRAME = "DQ+D8AIDAQBuAgMnAQa/qWp4qtoAxYYh"
 COFFEE_SIGNATURE = bytes.fromhex("00c58621")
@@ -1290,3 +1336,66 @@ def test_no_call_site_is_left_without_a_timeout():
     assert len(calls) == 8, f"expected 8 call sites, found {len(calls)}"
     for args in calls:
         assert "timeout=_TIMEOUT" in args, f"unbounded Ayla call: {args[:80]}"
+
+
+# --- buttons: availability (logbook "Pressed" storm) ------------------------
+
+def _buttons(coord):
+    """One instance of every button class the platform registers."""
+    bev_id, key, friendly, icon = const.BEVERAGES[0]
+    return [
+        button.DelonghiStartBeverageButton(coord, bev_id, key, friendly, icon),
+        button.DelonghiWakeButton(coord),
+        button.DelonghiStandbyButton(coord),
+        button.DelonghiStopButton(coord),
+        button.DelonghiDumpRecipesButton(coord),
+    ]
+
+
+def test_the_stub_still_ties_availability_to_the_poll():
+    """Control group: without the override, a failed poll takes an entity out.
+
+    Everything below asserts that buttons do NOT follow the coordinator, which
+    would pass just as well against a stub that never made anything unavailable.
+    """
+
+    class _Plain(_StubCoordinatorEntity):
+        pass
+
+    coord = _coord("DL-millcore")
+    entity = _Plain(coord)
+    assert entity.available is True
+    coord.last_update_success = False
+    assert entity.available is False
+
+
+def test_buttons_stay_available_across_a_failed_poll():
+    """The logbook renders every button state change as "Pressed".
+
+    A single Ayla 504 took the whole platform unavailable, and the return trip
+    to `unknown` 30 s later was drawn as every button being pressed in the same
+    second - and fires any `state` trigger watching them. Nothing was sent to
+    the machine; the logbook simply has no other word for a button. Keeping the
+    entities available removes the state change that is being mislabelled.
+    """
+    coord = _coord("DL-millcore")
+    coord.last_update_success = False
+    for entity in _buttons(coord):
+        assert entity.available is True, f"{type(entity).__name__} went unavailable"
+
+
+def test_an_available_button_still_refuses_an_offline_machine():
+    """Availability is not the guard - the coordinator preflight is.
+
+    This is what makes the constant `available` safe: pressability says nothing
+    about whether the command will be sent, and an Offline machine still gets
+    the refusal (with a user-visible error) rather than a write Ayla accepts and
+    never delivers.
+    """
+    coord = _coord("DL-millcore", connection_status="Offline", client=_RecordingClient())
+    coord.last_update_success = False
+    entity = _buttons(coord)[0]
+    assert entity.available is True
+    with pytest.raises(_StubHomeAssistantError):
+        asyncio.run(entity.async_press())
+    assert coord.client.writes == []


### PR DESCRIPTION
The `button.py` `available` override you asked for in #35 ([review comment](https://github.com/actabi/delonghi_coffeelink/pull/35#issuecomment-5533008397)). It is independent of that PR: it touches neither `ayla_client.py` nor the coordinator, so part 1 there can land before or after this without a conflict.

## What it looked like here

Same artefact, second machine (ECAM610.55 / `DL-millcore`), on 2026-09-07:

```
15:51:25.054 ERROR [custom_components.delonghi_coffeelink.coordinator]
  Error fetching delonghi_coffeelink_<dsn> data: Error fetching Delonghi data: 504,
  message='Attempt to decode JSON with unexpected mimetype: text/plain',
  url='https://ads-eu.aylanetworks.com/apiv1/dsns/<dsn>/properties.json'
```

Recorder history for one button across that window:

| state | when |
| --- | --- |
| `unavailable` | 15:51:25 |
| `unknown` | 15:51:55 |

No timestamp state, so no press: a `ButtonEntity`'s state *is* its last-press timestamp, and the one button on this machine that has ever been pressed still reads `2026-08-23T08:27:07.469793+00:00`. The logbook showed the whole beverage list as "Pressed" at 15:51:55.

`localizeStateMessage` in the frontend's `src/data/logbook.ts` maps the domain through `STATE_ACTION_MESSAGES` (`button: "pressed"`) and returns that without reading the state value, so any state change of a button is a press as far as the logbook is concerned.

## The change

`_Base.available` returns `True`. A button has no state of its own to lose, so tracking `last_update_success` bought no information and cost the fabricated rows.

Reachability stays where it was: `_ensure_machine_reachable` refuses to write to a machine the cloud reports Offline and raises a user-visible error, and it reads the device's `connection_status` rather than our poll health, so a pressable button is not a sendable one. `binary_sensor.py:95` is the precedent for a platform narrowing what the coordinator's flag means for it.

Sensors and binary sensors are untouched and still go unavailable, which is correct. They carry readings, and a reading that is hours old shown as current is worse than no reading.

## Tests

Three cases in `test_coordinator_session.py`, the module whose docstring says it owns the coordinator stubs.

- `test_buttons_stay_available_across_a_failed_poll` covers one instance of every button class the platform registers, not just the beverage one.
- `test_an_available_button_still_refuses_an_offline_machine` presses a button on an Offline machine with `last_update_success` false, and asserts the refusal raises and that nothing was written.
- `test_the_stub_still_ties_availability_to_the_poll` is a control group. "Stays available" would pass just as well against a stub that never made anything unavailable, so a plain `CoordinatorEntity` subclass is asserted to still follow the last poll.

Verified by reverting only the override: the two behaviour tests fail, the control group passes. `278 passed`, `ruff check` clean.

The stubs gained the platform imports `button.py` needs (`ButtonEntity`, `DeviceInfo`, `EntityCategory`, `ConfigEntry`, `AddEntitiesCallback`) plus a `CoordinatorEntity` whose `available` mirrors HA's own, since that is the behaviour under test.

## What this does not fix

The 504 itself, and the sensor flap it causes. That is #35 part 1: `async_get_properties` and `async_get_devices` still do a bare `session.get()` + `resp.json()` on `main` and never reach `_request_json`. This change removes the fabricated presses whether or not a poll fails; it does not make fewer polls fail.

Not deployed to my machine yet - it is running `main`. Happy to run it for a few days before you merge if you would rather have that.
