### PR TITLE
fix: hassfest rejects a device filter on a service target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## [Unreleased]
+
+### Fixed
+- **Hassfest rejected `services.yaml`, so CI has been red since 0.3.24.** The
+  per-device targeting added there filtered the target block by device:
+
+  ```yaml
+  target:
+    device:
+      integration: delonghi_coffeelink
+  ```
+
+  Home Assistant does not allow that. `script/hassfest/services.py` refuses any
+  `device` key under `target` outright - "Services do not support device filters
+  on target, use a device selector instead" - and it said so for all three
+  services. The filter is now on `entity`, which is what core's own integrations
+  use for the same job (see `reolink/services.yaml`).
+
+  No behaviour changes. The block only filters what the UI target picker offers;
+  the handler reads `device_id`, `entity_id`, `area_id`, `floor_id` and
+  `label_id` straight out of `call.data` and resolves them itself, so picking a
+  machine still sends `device_id` exactly as before.
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/custom_components/delonghi_coffeelink/services.yaml
+++ b/custom_components/delonghi_coffeelink/services.yaml
@@ -1,6 +1,6 @@
 start_beverage:
   target:
-    device:
+    entity:
       integration: delonghi_coffeelink
   fields:
     beverage:
@@ -34,7 +34,7 @@ start_beverage:
 
 stop_beverage:
   target:
-    device:
+    entity:
       integration: delonghi_coffeelink
   fields:
     beverage:
@@ -53,7 +53,7 @@ stop_beverage:
 
 send_raw_command:
   target:
-    device:
+    entity:
       integration: delonghi_coffeelink
   fields:
     value_base64:


### PR DESCRIPTION
CI has been red on `main` since 3120cf2 (0.3.24). Hassfest refuses any `device` key under `target`:

```
[ERROR] [SERVICES] Invalid services.yaml: Services do not support device filters
on target, use a device selector instead at 'send_raw_command.target'.
Got {'device': {'integration': 'delonghi_coffeelink'}}
```

and the same for `start_beverage.target` and `stop_beverage.target`. The rule is unconditional, in `script/hassfest/services.py`:

```python
def raise_on_target_device_filter(value: dict[str, Any]) -> dict[str, Any]:
    """Raise error if target has a device filter."""
    if "device" in value:
        raise vol.Invalid(
            "Services do not support device filters on target, use a device "
            "selector instead"
        )
```

The last green run on `main` was 1136b61 (release 0.3.23).

### The change

The filter moves from `device` to `entity` on all three services, which is what core's own integrations use for the same job (`reolink/services.yaml` targets `entity: integration: reolink`).

### Why nothing behaves differently

The `target` block only filters what the UI target picker offers. `_resolve_targets` reads `device_id`, `entity_id`, `area_id`, `floor_id` and `label_id` out of `call.data` itself, so picking a machine still sends `device_id` exactly as before, and the per-device targeting from 0.3.24 keeps working unchanged.

Found while a feature branch of mine inherited the red check. Sent separately so the fix does not ride along inside an unrelated feature.

345 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
